### PR TITLE
Add developer documentation (docs/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ You are a fantastic developer. Keep your CV on GitHub, exploiting Node.js GitHub
 * Dockerized for easy building and deployment.
 * Github Actions for CI/CD. (Currently only for CI, CD is manual for now)
 
+## Documentation
+
+Developer documentation lives in [`docs/`](docs/):
+
+- [Architecture](docs/architecture.md) — code structure, the build pipeline, the content data model, and how the site is served.
+- [CI/CD](docs/ci-cd.md) — GitHub Actions workflows and the manual Docker-based deployment.
+
 ## Dependencies
 
 This project leverages Docker and Docker Compose for building and deploying the page. It's recommended to install Docker and Docker Compose to streamline the development process and avoid the need for local dependencies.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Documentation
+
+Developer documentation for the CV project — a small Node.js static-site generator that renders
+a single-page CV to HTML + PDF and serves it at [valerio.dev](https://valerio.dev).
+
+For day-to-day commands (build, lint, deploy), see the root [`README.md`](../README.md). For an
+agent-oriented quick reference, see [`AGENTS.md`](../AGENTS.md).
+
+## Contents
+
+- **[Architecture](architecture.md)** — code structure, the build pipeline, the content data
+  model, and how the site is served.
+- **[CI/CD](ci-cd.md)** — GitHub Actions workflows and the (manual) Docker-based deployment.
+- **[Contributing & Issue Tracking](contributing.md)** — how work is tracked in GitHub (issues,
+  milestones, projects) and how to raise a well-formed issue.
+
+## At a glance
+
+| Aspect        | Summary                                                                 |
+| ------------- | ----------------------------------------------------------------------- |
+| Language      | JavaScript (Node.js)                                                    |
+| Templating    | Handlebars                                                              |
+| PDF           | Puppeteer (headless Chrome)                                             |
+| Content       | A single data file: `src/metadata/metadata.js`                          |
+| Output        | `dist/` (generated, gitignored)                                         |
+| Serving       | nginx (Docker Compose) with Let's Encrypt TLS via certbot               |
+| CI            | GitHub Actions — Super-Linter (lint-only, no tests)                     |
+| CD            | Manual (`make` targets on the host)                                     |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,115 @@
+# Architecture
+
+The project is a static-site generator with one job: turn a structured CV data file into a
+single HTML page and a matching PDF, then serve those static files behind nginx. There is no
+backend, database, or client-side framework — the page is plain HTML/CSS produced at build time.
+
+## Directory layout
+
+```
+.
+├── src/
+│   ├── build.js                  # Build entrypoint: data + template → dist/
+│   ├── metadata/
+│   │   └── metadata.js           # CV content — the data model (see below)
+│   ├── templates/
+│   │   └── index.html            # Handlebars page template (Bootstrap 5 markup)
+│   ├── assets/                   # Copied verbatim into dist/: styles.css, photo.jpg,
+│   │                             #   favicons, url-qr-code.svg
+│   └── utils/
+│       ├── pdf.js                # Puppeteer HTML → PDF renderer
+│       └── helpers/
+│           └── markdown.js       # Handlebars {{markdown}} helper
+├── config/
+│   ├── lint/super-linter.env     # Super-Linter configuration (see ci-cd.md)
+│   └── nginx/                    # Webserver image + site configs (see ci-cd.md)
+├── Dockerfile                    # Builder image: node:14 + Chrome for Puppeteer
+├── docker-compose.yml            # Services: app-builder, webserver, certbot
+├── Makefile                      # Dev, build, and deploy commands
+├── package.json                  # npm scripts + dependencies
+└── .github/workflows/
+    └── superlinter.yml           # CI: lint on push / PR
+```
+
+`dist/` is the build output and is gitignored — never edit it by hand.
+
+## Build pipeline
+
+The whole build is `src/build.js`, run via `node src/build.js` (wrapped by `npm run build` and
+`make page`). In order, it:
+
+1. **Empties `dist/`** — `fs.emptyDirSync(outputDir)` (`outputDir` = `<repo>/dist`).
+2. **Copies assets** — `src/assets/` → `dist/` verbatim (styles, photo, favicons, QR code).
+3. **Registers the `markdown` helper** so templates can render Markdown content fields to HTML.
+4. **Compiles the template** — reads `src/templates/index.html`, compiles it with Handlebars, and
+   renders it with the data from `src/metadata/metadata.js` plus three injected values:
+   - `baseUrl` — `https://valerio.dev`
+   - `pdfFileName` — slugified `"<name>.<title>.pdf"` (via `speakingurl`)
+   - `updated` — today's date, formatted with `dayjs` (`MMMM D, YYYY`)
+5. **Writes `dist/index.html`**.
+6. **Generates the PDF** — `src/utils/pdf.js` launches headless Chrome (Puppeteer), loads the
+   freshly written `dist/index.html` as a `file://` URL (waiting for `networkidle0`), and prints
+   an **A4** PDF with **2.54 cm** margins to `dist/<pdfFileName>`.
+
+```
+metadata.js ─┐
+             ├─▶ Handlebars ─▶ dist/index.html ─▶ Puppeteer ─▶ dist/<name>.<title>.pdf
+index.html ──┘                      ▲
+                                src/assets/ (copied into dist/)
+```
+
+Because the PDF is rendered from the same HTML, the HTML and PDF versions stay consistent by
+construction. The CSS uses `screen` / `print` classes to vary output: the on-screen page shows a
+"Download PDF" link, while the print/PDF version shows a QR code to the site instead
+(`src/templates/index.html`).
+
+## Content data model
+
+All CV content lives in `src/metadata/metadata.js`, which exports a single object. This is the
+**only** file you edit to update CV content. Top-level keys:
+
+| Key            | Type     | Notes                                                              |
+| -------------- | -------- | ------------------------------------------------------------------ |
+| `name`         | string   | Used in the title, header, and PDF filename slug.                  |
+| `title`        | string   | Role/headline; also part of the PDF filename slug.                 |
+| `facts`        | array    | Contact/location items, each `{ icon, value }` (raw HTML strings). |
+| `about_me`     | string   | Markdown — rendered via the `{{markdown}}` helper.                 |
+| `skills`       | array    | Tuples `[label, percent]`; `percent` drives the skill-bar width.   |
+| `positions`    | array    | Professional experience (see entry shape below).                   |
+| `experience`   | array    | Additional experience (same entry shape).                          |
+| `competitions` | array    | Robotics competitions (same shape, without `skills`).              |
+
+Experience-style entries (`positions`, `experience`, `competitions`) have:
+
+- `title` — string
+- `period` — string (e.g. `"November 2023 – Present"`)
+- `contents` — Markdown string, rendered with `{{markdown}}`
+- `skills` — array of strings, rendered as badges (omitted for `competitions`)
+
+`icon` and `value` in `facts` are interpolated as raw HTML (`{{{ }}}`), so they can contain
+Font Awesome `<i>` tags and `<a>` links.
+
+## Template & styling
+
+- `src/templates/index.html` is a Handlebars template producing a Bootstrap 5 single-page layout.
+  External assets are loaded from CDNs at runtime: Bootstrap 5.2, Font Awesome 6.1, and the
+  Roboto Google Font.
+- Sections rendered: header (photo + name + facts + PDF/QR), About me, Skills (bar chart),
+  Professional Experience, Additional Experience, Robotics Competitions. Lists use Handlebars
+  `{{#each}}` over the arrays above.
+- `src/assets/styles.css` holds project-specific styling on top of Bootstrap, including the
+  `screen` / `print` visibility rules and the skill-bar styling.
+- Note: this template/repo originates from the [`sneas/cv-template`](https://github.com/sneas/cv-template)
+  project (see the commented-out section in the root README).
+
+## Runtime & dependencies
+
+- Local builds use your system Node.js. The **Docker** builder image pins `node:14` and installs
+  a fixed Chrome build (127) plus CJK/Thai/Arabic fonts so Puppeteer can render the PDF
+  consistently inside the container (`Dockerfile`).
+- Key npm dependencies (`package.json`): `handlebars` (templating), `puppeteer` (PDF),
+  `fs-extra` (file ops), `dayjs` (dates), `speakingurl` (slugs), `markdown` (Markdown→HTML),
+  plus dev tooling: `live-server` + `chokidar-cli`/`watch` (dev server), `stylelint`, and
+  `gh-pages`.
+
+For how the built site is served and deployed, see [ci-cd.md](ci-cd.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ backend, database, or client-side framework — the page is plain HTML/CSS produ
 
 ## Directory layout
 
-```
+```text
 .
 ├── src/
 │   ├── build.js                  # Build entrypoint: data + template → dist/
@@ -51,7 +51,7 @@ The whole build is `src/build.js`, run via `node src/build.js` (wrapped by `npm 
    freshly written `dist/index.html` as a `file://` URL (waiting for `networkidle0`), and prints
    an **A4** PDF with **2.54 cm** margins to `dist/<pdfFileName>`.
 
-```
+```text
 metadata.js ─┐
              ├─▶ Handlebars ─▶ dist/index.html ─▶ Puppeteer ─▶ dist/<name>.<title>.pdf
 index.html ──┘                      ▲

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -98,7 +98,7 @@ HTTP before certs exist.
 
 ### Deployment flow
 
-```
+```text
 make build ─▶ html volume ─▶ webserver (nginx :80, valerio.dev config, /healthcheck)
                                    │
                    make webserver-upgrade-to-https

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,119 @@
+# CI/CD
+
+CI is automated and lint-only. Deployment (CD) is **manual** — there is no pipeline that ships the
+site; a human runs `make` targets on the host that serves [valerio.dev](https://valerio.dev).
+
+## Continuous Integration — GitHub Actions
+
+One workflow: **`.github/workflows/superlinter.yml`** (name: `Lint`).
+
+- **Triggers:** every `push` and every `pull_request`.
+- **Runner:** `ubuntu-latest`.
+- **Steps:**
+  1. Checkout with `fetch-depth: 0` — Super-Linter needs full git history to diff changed files.
+  2. Load `config/lint/super-linter.env` into `$GITHUB_ENV`.
+  3. Run `super-linter/super-linter@v6.7.0`, reporting results as GitHub status checks
+     (`permissions: statuses: write`, using the default `GITHUB_TOKEN`).
+- A Super-Linter status badge is shown at the top of the root [`README.md`](../README.md).
+
+There are **no automated tests** and **no build/deploy** in CI — linting is the only gate.
+
+### Linter configuration
+
+Defined in `config/lint/super-linter.env`:
+
+| Setting                          | Value / effect                                                  |
+| -------------------------------- | --------------------------------------------------------------- |
+| `DEFAULT_BRANCH`                 | `main`                                                          |
+| `FILTER_REGEX_EXCLUDE`           | `.src/templates/*` — Handlebars templates are not linted.       |
+| `IGNORE_GITIGNORED_FILES`        | `true`                                                          |
+| `LINTER_RULES_PATH`              | `config/lint`                                                   |
+| Enabled validators               | CSS, Dockerfile (hadolint), GitHub Actions, HTML, JavaScript (`standard`), JSON, JSX, Markdown, TypeScript (`standard`), XML, YAML |
+
+JavaScript is checked against the **`standard`** style; CSS uses `stylelint` with
+`stylelint-config-standard` (declared in `package.json`).
+
+### Running CI locally
+
+```sh
+make lint
+```
+
+This runs the same Super-Linter image in Docker with `RUN_LOCAL=true`, using
+`config/lint/super-linter.env`, so you can reproduce CI results before pushing.
+
+## Continuous Deployment — manual, Docker-based
+
+The site is self-hosted. Deployment is orchestrated by the `Makefile` and `docker-compose.yml`,
+which define three services sharing two named volumes:
+
+| Service           | Role                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `app-builder`     | Builds the site (the `Dockerfile` builder image) into the `html` volume. |
+| `webserver`       | nginx serving the `html` volume on ports 80/443 (`config/nginx/`).   |
+| `certbot` / `certbot-dry-run` | Issues Let's Encrypt certs for `valerio.dev` + `www.valerio.dev` into the `certs` volume. |
+
+| Volume  | Purpose                                                              |
+| ------- | ------------------------------------------------------------------- |
+| `html`  | The built static site, shared by `app-builder`, `webserver`, `certbot`. |
+| `certs` | `/etc/letsencrypt` — TLS certificates.                              |
+
+### Deploy commands
+
+```sh
+make build                      # Build the site into the html volume (via app-builder)
+make webserver                  # Start nginx (HTTP only)
+make webserver-upgrade-to-https # Issue certs, swap to SSL config, reload nginx
+make all                        # First-time only: build + serve + HTTPS (recreates certs!)
+```
+
+- `make all` is for a **first-time** stand-up. Avoid it for routine content updates because it
+  recreates certificates.
+- For a routine content update: `make build` to rebuild, then redeploy/reload the webserver.
+
+### TLS / certbot
+
+- `make certificates` runs certbot for real; `make certificates-dry-run` simulates issuance.
+- **Let's Encrypt has strict rate limits.** Always validate with `make certificates-dry-run`
+  before `make certificates` / `make webserver-upgrade-to-https`, or you can be temporarily
+  blocked from issuing certs.
+- `make webserver-upgrade-to-https` runs certbot, swaps nginx to the SSL site config
+  (`valerio-ssl.conf`), and reloads nginx (`webserver-ssl-config` + `webserver-restart-nginx`).
+
+### nginx configuration
+
+The webserver image (`config/nginx/Dockerfile`, `nginx:alpine`) selects which site config to
+enable via the `SITE_NAME` build arg, symlinking it into `sites-enabled/`. Three configs live in
+`config/nginx/sites-available/`:
+
+| Config               | Behavior                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| `valerio.dev`        | HTTP-only (pre-TLS). Serves the ACME challenge path and `/healthcheck`; `/` returns 404.  |
+| `valerio-ssl.conf`   | Redirects HTTP → HTTPS; serves the site over 443 using the Let's Encrypt cert/key.        |
+| `valerio-local.conf` | Same as `valerio.dev` but also matches `localhost`, for local testing.                    |
+
+All variants expose `/healthcheck` (also used by the `webserver` healthcheck in
+`docker-compose.yml`). The ACME challenge location is what lets certbot validate the domain over
+HTTP before certs exist.
+
+### Deployment flow
+
+```
+make build ─▶ html volume ─▶ webserver (nginx :80, valerio.dev config, /healthcheck)
+                                   │
+                   make webserver-upgrade-to-https
+                                   │
+                   certbot (ACME challenge via :80) ─▶ certs volume
+                                   │
+                   swap to valerio-ssl.conf + reload ─▶ nginx :443 (HTTPS)
+```
+
+### Helpful operational targets
+
+```sh
+make logs-webserver       # nginx logs
+make logs-app-builder     # build logs
+make logs-certbot         # certbot logs
+make down                 # stop the webserver (docker compose down)
+make dev-build            # dockerized build, copied back into local ./dist
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,7 +42,7 @@ A well-formed issue has:
 
 Reference the issue in the PR description with a closing keyword so it auto-closes on merge:
 
-```
+```text
 Closes #123
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,77 @@
+# Contributing & Issue Tracking
+
+All work on this repo is tracked in **GitHub** — Issues, Milestones, and Projects. Open an issue
+before starting non-trivial work so the change is visible, reviewable, and linked to its goal.
+
+## Where work lives
+
+| Tool         | Purpose                                                                          |
+| ------------ | -------------------------------------------------------------------------------- |
+| Issues       | One unit of work — a bug, feature, doc change, or chore.                          |
+| Milestones   | Group related issues that together deliver a goal (e.g. "Set up Claude Code for this repo"). |
+| Projects     | Board view for status (Todo / In progress / Done).                                |
+
+## Raising an issue
+
+A well-formed issue has:
+
+1. **Title** — short and imperative: "Add X", "Fix Y", "Document Z".
+2. **Type label** — one of:
+   - `documentation` — docs, `AGENTS.md`, `README` changes
+   - `enhancement` — a new capability or improvement
+   - `bug` — something is broken
+   - `maintenance` — chores, tooling, refactors (e.g. Makefile cleanup)
+3. **Body**, using this structure:
+
+   ```markdown
+   ## Context
+   Why this matters / the problem being solved.
+
+   ## Acceptance criteria
+   - [ ] What "done" looks like, as a checklist
+   - [ ] ...
+
+   ## References
+   - Links to related files, issues, PRs, or docs
+   ```
+
+4. **Milestone** — assign it when the issue is part of a larger effort.
+5. **Project** — add it to the board so status is tracked.
+
+## Linking pull requests
+
+Reference the issue in the PR description with a closing keyword so it auto-closes on merge:
+
+```
+Closes #123
+```
+
+## Doing it from the CLI (`gh`)
+
+Create an issue:
+
+```sh
+gh issue create \
+  --title "Document the build pipeline" \
+  --label documentation \
+  --milestone "Set up Claude Code for this repo" \
+  --body "## Context
+...
+
+## Acceptance criteria
+- [ ] ...
+"
+```
+
+Create a milestone (no native `gh` subcommand — use the REST API):
+
+```sh
+gh api --method POST repos/{owner}/{repo}/milestones -f title="Set up Claude Code for this repo"
+```
+
+List work:
+
+```sh
+gh issue list --milestone "Set up Claude Code for this repo"
+gh api repos/{owner}/{repo}/milestones
+```


### PR DESCRIPTION
## Summary
Kickstarts developer documentation for the repo (it had none) in a new `docs/` folder.

## Changes
- `docs/README.md` — documentation index + at-a-glance overview table
- `docs/architecture.md` — code structure, the build pipeline, the content data model (`src/metadata/metadata.js`), and how the site is served
- `docs/ci-cd.md` — the GitHub Actions lint workflow and the manual Docker-based deployment (services, volumes, nginx configs, certbot)
- `docs/contributing.md` — how work is tracked in GitHub (issues, milestones, projects) and how to raise a well-formed issue
- `README.md` — adds a Documentation section linking into `docs/`

## Note
`docs/README.md` links to `../AGENTS.md`, which lands in a follow-up PR (#10). The link is valid once that PR is merged.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)