### PR TITLE
docs: emphasize validating CI locally before pushing

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -33,14 +33,26 @@ Defined in `config/lint/super-linter.env`:
 JavaScript is checked against the **`standard`** style; CSS uses `stylelint` with
 `stylelint-config-standard` (declared in `package.json`).
 
-### Running CI locally
+### Validate locally before pushing
+
+Linting is the only CI gate, and it is fully reproducible locally — run it before opening or
+updating a PR to get feedback in one pass instead of the push-and-wait cycle:
 
 ```sh
 make lint
 ```
 
-This runs the same Super-Linter image in Docker with `RUN_LOCAL=true`, using
-`config/lint/super-linter.env`, so you can reproduce CI results before pushing.
+This runs the **same** Super-Linter image in Docker with `RUN_LOCAL=true`, using
+`config/lint/super-linter.env`, so a local pass closely matches the CI result.
+
+Caveats:
+
+- **Image version:** `make lint` pulls `super-linter:latest`, while CI pins `v6.7.0`
+  (`.github/workflows/superlinter.yml`). Results can drift slightly between versions.
+- **Scope:** locally, Super-Linter lints the whole workspace; in CI it lints only files changed
+  against `main`. Local is broader, not narrower.
+- **Vercel:** the deploy-preview check runs on Vercel's side and is **not** covered by `make lint`;
+  it can only be validated after pushing.
 
 ## Continuous Deployment — manual, Docker-based
 


### PR DESCRIPTION
## Summary
Follow-up to #14. Expands the CI docs to make local validation the default workflow: run `make lint` (the same Super-Linter image CI uses) before opening/updating a PR, instead of waiting on PR checks.

## Changes
- `docs/ci-cd.md` — reframe "Running CI locally" → "Validate locally before pushing", with caveats:
  - local uses `super-linter:latest` while CI pins `v6.7.0`
  - local lints the whole workspace; CI lints only files changed vs `main`
  - the Vercel deploy-preview check is **not** reproducible locally

Paired with a matching guardrail added to `AGENTS.md` in #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)