### PR TITLE
Add self-review gate: >10-line changes require /code-review

### DIFF
--- a/.claude/hooks/review-gate.sh
+++ b/.claude/hooks/review-gate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Self-review gate — a Claude Code "Stop" hook.
+#
+# Blocks finishing a turn when the reviewable diff (excluding generated files)
+# exceeds THRESHOLD changed lines and this exact diff has not been recorded as
+# reviewed. To clear it: run /code-review, address the findings, then record:
+#
+#     bash <this-script> record
+#
+# Threshold is 10 by default; override per-project with REVIEW_GATE_THRESHOLD
+# (non-integer values are ignored). Requires git and jq; without either the gate
+# no-ops (fails open) rather than wedging a turn.
+#
+# NOTE: as a Stop hook this is a strong *nudge*, not an ironclad gate — an agent
+# that ignores the block and stops again is let through (the stop_hook_active
+# loop guard). CI is the enforcement layer for changes that must not merge
+# unreviewed.
+
+THRESHOLD="${REVIEW_GATE_THRESHOLD:-10}"
+case "$THRESHOLD" in ''|*[!0-9]*) THRESHOLD=10 ;; esac
+
+# Generated / vendored paths that should neither count toward the threshold nor
+# need human-style review.
+EXCLUDES=(
+  ':(exclude)package-lock.json'   ':(exclude)**/package-lock.json'
+  ':(exclude)yarn.lock'           ':(exclude)**/yarn.lock'
+  ':(exclude)pnpm-lock.yaml'      ':(exclude)**/pnpm-lock.yaml'
+  ':(exclude)poetry.lock'         ':(exclude)Cargo.lock'
+  ':(exclude)go.sum'              ':(exclude)composer.lock'
+  ':(exclude)dist/**'             ':(exclude)build/**'
+  ':(exclude)**/*.min.js'         ':(exclude)**/*.min.css'
+)
+
+# Not a git repo → nothing to gate.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# What to diff against:
+#   - unborn HEAD (fresh repo, no commit yet) → staged work (--cached)
+#   - otherwise → merge-base with the default branch (captures branch commits +
+#     uncommitted; on the default branch this collapses to HEAD, i.e. uncommitted)
+if git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+  base=""
+  for r in origin/HEAD origin/main origin/master main master; do
+    if git rev-parse --verify --quiet "$r" >/dev/null 2>&1; then
+      base="$(git merge-base HEAD "$r" 2>/dev/null)"
+      break
+    fi
+  done
+  [ -z "$base" ] && base="HEAD"
+  diffbase=("$base")
+else
+  diffbase=(--cached)
+fi
+
+changed="$(git diff --numstat "${diffbase[@]}" -- . "${EXCLUDES[@]}" 2>/dev/null \
+  | awk '{a+=$1; d+=$2} END {print a+d+0}')"
+[ -z "$changed" ] && changed=0
+
+diff_hash="$(git diff "${diffbase[@]}" -- . "${EXCLUDES[@]}" 2>/dev/null | git hash-object --stdin 2>/dev/null)"
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+key="$(printf '%s' "$root" | git hash-object --stdin 2>/dev/null | cut -c1-16)"
+marker="$HOME/.claude/.review-markers/$key"
+
+# record mode: stamp the current reviewable diff as reviewed.
+if [ "${1:-}" = "record" ]; then
+  mkdir -p "$HOME/.claude/.review-markers"
+  printf '%s\n' "$diff_hash" > "$marker"
+  echo "Recorded self-review for ${changed} reviewable line(s)."
+  exit 0
+fi
+
+# Hook mode needs jq (payload parse + JSON output); without it, no-op (fail open).
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Read the hook payload from stdin.
+stop_active="$(cat 2>/dev/null | jq -r '.stop_hook_active // false' 2>/dev/null)"
+
+# Already re-prompted once this stop-cycle → don't loop.
+[ "$stop_active" = "true" ] && exit 0
+
+# If this is the user-global copy and the project ships its own gate, defer to
+# the project copy so we don't emit a duplicate block. Resolve the project dir
+# from CLAUDE_PROJECT_DIR, falling back to the git root.
+self="${BASH_SOURCE[0]}"
+proj_dir="${CLAUDE_PROJECT_DIR:-$root}"
+case "$self" in
+  "$HOME/.claude/hooks/review-gate.sh")
+    [ -n "$proj_dir" ] && [ -f "$proj_dir/.claude/hooks/review-gate.sh" ] && exit 0
+    ;;
+esac
+
+# Under threshold → allow.
+[ "$changed" -le "$THRESHOLD" ] 2>/dev/null && exit 0
+
+# This exact diff already recorded as reviewed → allow.
+[ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$diff_hash" ] && exit 0
+
+# Otherwise block and ask for a review.
+reason="Self-review required before finishing: ${changed} reviewable lines changed (threshold ${THRESHOLD}) and this diff has not been reviewed. Run /code-review, address the findings, then record it:  bash \"$self\" record"
+jq -cn --arg r "$reason" '{decision:"block", reason:$r}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/review-gate.sh\"",
+            "statusMessage": "Checking self-review gate..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,21 @@ Deploy is **manual**:
 - After content or template changes, run `make page` and open `dist/index.html` to verify both the
   HTML and the generated PDF render correctly.
 
+## Self-review (required for changes over 10 lines)
+
+After a change touching **more than 10 reviewable lines** (excluding generated files such as
+`package-lock.json` and `dist/`), and before reporting it done or opening a PR, run an independent
+self-review and act on it:
+
+- Invoke `/code-review`. It fans out fresh reviewer agents that critique the diff adversarially
+  (correctness, removed behavior, robustness), then verify findings. Independence is the point —
+  reviewers must not be anchored to the code as written.
+- Fix confirmed findings; state explicitly anything you deliberately defer.
+
+This is enforced by a `Stop` hook (`.claude/hooks/review-gate.sh`) that blocks finishing until the
+current diff is recorded as reviewed. After reviewing, record it (the block message prints the
+exact command): `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/review-gate.sh" record`.
+
 ## Issue Tracking
 
 Work is tracked in **GitHub Issues, Milestones, and Projects** — see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,12 @@ This is enforced by a `Stop` hook (`.claude/hooks/review-gate.sh`) that blocks f
 current diff is recorded as reviewed. After reviewing, record it (the block message prints the
 exact command): `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/review-gate.sh" record`.
 
+## Keep docs in sync
+
+When a change alters behavior, commands, architecture, or workflow, update the relevant docs in the
+**same PR** — `docs/` (`architecture.md`, `ci-cd.md`, `contributing.md`), the root `README.md`, and
+this `AGENTS.md`. A change that outdates a doc isn't done until the doc is fixed.
+
 ## Issue Tracking
 
 Work is tracked in **GitHub Issues, Milestones, and Projects** — see

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,6 +46,23 @@ Reference the issue in the PR description with a closing keyword so it auto-clos
 Closes #123
 ```
 
+## Self-review before a PR
+
+Any change over **10 reviewable lines** (excluding generated files like `package-lock.json` and
+`dist/`) is self-reviewed before it's opened or reported done:
+
+1. Run `/code-review` in Claude Code — it spawns independent reviewers that critique the diff
+   (correctness, removed behavior, robustness) and verify findings.
+2. Fix the confirmed findings; note anything you deliberately defer.
+3. Record the review so the gate clears (the block message prints the exact command):
+   `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/review-gate.sh" record`
+
+A `Stop` hook (`.claude/hooks/review-gate.sh`) enforces this locally for Claude Code users: it
+blocks finishing a turn until the current diff is recorded as reviewed. It is a strong reminder, not
+a hard gate — an ignored block eventually lets go, and it only runs for contributors using Claude
+Code, so treat it as a prompt to review rather than a guarantee. Tune the threshold per-project with
+`REVIEW_GATE_THRESHOLD`.
+
 ## Doing it from the CLI (`gh`)
 
 Create an issue:


### PR DESCRIPTION
## Summary
An objective self-review gate: any change over **10 reviewable lines** must pass `/code-review` before it's reported done. Part of #20 (agentic tooling / `.claude/settings.json`).

## What
- **AGENTS.md** — documents the rule (proactive driver; objective, judgment-free threshold).
- **`.claude/hooks/review-gate.sh`** — a `Stop` hook enforcing it. Measures the reviewable diff (excludes lockfiles/`dist`) vs the default-branch merge-base; blocks finishing until the exact diff is recorded reviewed. Fails open (needs git+jq), respects `stop_hook_active` (no loops), tunable via `REVIEW_GATE_THRESHOLD`, handles unborn HEAD, and defers to the project copy so a user-global copy doesn't double-block.
- **`.claude/settings.json`** — wires the `Stop` hook (committed, so contributors get it after trusting project hooks).

## Honest limits
- This is the **local** layer. A Stop hook is a strong *nudge*, not ironclad — an agent that ignores the block and re-stops is let through (loop-safety), and it only applies to contributors using Claude Code. The **universal** gate would be a CI PR check (deferred).

## Verified
The hook was itself run through `/code-review`; fixes applied (integer-sanitize threshold — was fail-closed; explicit no-op without jq; unborn-HEAD; defer fallback). Tested across block / loop-guard / threshold / record / defer / unborn-HEAD paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)