### PR TITLE
Add core devcontainer (Node 22 + Playwright + Docker + Python/uv)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "cv",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    }
+  },
+  "forwardPorts": [
+    8080
+  ],
+  "portsAttributes": {
+    "8080": {
+      "label": "CV preview (live-server)",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci && npx --yes playwright install --with-deps chromium && pip install --root-user-action=ignore uv",
+  "remoteUser": "root"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ and run that instead — the targets encode the correct flags, container names, 
 ordering. The targets are commented; read the `Makefile` to find the right one. The only common
 task not wrapped by a target is the local watch dev server (`npm start`).
 
+- **Dev Container (recommended)** — open `.devcontainer/` (`devcontainer up` or VS Code "Reopen in
+  Container") for a reproducible environment with Node 22, the Playwright Chromium, Docker access,
+  and Python + uv; every target below works inside it. It runs as `root` with host Docker access.
 - `npm start` — build + watch + live-server dev server (needs node/npm locally).
 - `make page` — one-off local build into `dist/` (needs node/npm).
 - `make dev-build` — dockerized build that copies output into local `dist/` (no local node needed).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ and run that instead — the targets encode the correct flags, container names, 
 ordering. The targets are commented; read the `Makefile` to find the right one. The only common
 task not wrapped by a target is the local watch dev server (`npm start`).
 
-- **Dev Container (recommended)** — open `.devcontainer/` (`devcontainer up` or VS Code "Reopen in
-  Container") for a reproducible environment with Node 22, the Playwright Chromium, Docker access,
+- **Dev Container (recommended)** — `make dev` (or VS Code "Reopen in Container") opens
+  `.devcontainer/`, a reproducible environment with Node 22, the Playwright Chromium, Docker access,
   and Python + uv; every target below works inside it. It runs as `root` with host Docker access.
 - `npm start` — build + watch + live-server dev server (needs node/npm locally).
 - `make page` — one-off local build into `dist/` (needs node/npm).

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += -s
 
-.PHONY: clean page lint build dev-build \
+.PHONY: dev clean page lint build dev-build \
 	logs-app-builder logs-webserver logs-certbot \
 	remove-app-builder remove-certbot \
 	certificates certificates-dry-run \
@@ -11,6 +11,11 @@ MAKEFLAGS += -s
 clean:
 	echo "Cleaning up..."
 	-rm -rf ./dist/ > /dev/null 2>&1
+
+# Open the project in its Dev Container (requires the devcontainer CLI)
+dev:
+	echo "Starting dev container..."
+	devcontainer up --workspace-folder .
 
 # Build the page using local environment
 # Dependencies: npm, node

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ If you do insist on building locally, you will need the following dependencies:
 * npm
 * node
 
+### Dev Container
+
+The quickest setup is the [Dev Container](.devcontainer/devcontainer.json): open the repo in it (VS Code "Reopen in Container", or `devcontainer up`) for a ready-made environment — Node 22, the Playwright Chromium used for the PDF build, Docker access for `make lint` / `make build`, and Python + uv — with no local Node or Chromium install.
+
+> The container runs as `root` and mounts the host Docker socket (both needed to run the Docker-based `make` targets from inside it), so treat it as having full host Docker access.
+
 ## Usage
 
 This project uses a Makefile and Docker to streamline various development tasks. Below are the available commands and their descriptions:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you do insist on building locally, you will need the following dependencies:
 
 ### Dev Container
 
-The quickest setup is the [Dev Container](.devcontainer/devcontainer.json): open the repo in it (VS Code "Reopen in Container", or `devcontainer up`) for a ready-made environment — Node 22, the Playwright Chromium used for the PDF build, Docker access for `make lint` / `make build`, and Python + uv — with no local Node or Chromium install.
+The quickest setup is the [Dev Container](.devcontainer/devcontainer.json): open the repo in it (VS Code "Reopen in Container", `make dev`, or `devcontainer up`) for a ready-made environment — Node 22, the Playwright Chromium used for the PDF build, Docker access for `make lint` / `make build`, and Python + uv — with no local Node or Chromium install.
 
 > The container runs as `root` and mounts the host Docker socket (both needed to run the Docker-based `make` targets from inside it), so treat it as having full host Docker access.
 
@@ -45,6 +45,10 @@ This project uses a Makefile and Docker to streamline various development tasks.
 
 ### Dev and Build
 
+- **dev**: Open the project in its [Dev Container](.devcontainer/devcontainer.json). Dependencies: devcontainer CLI
+  ```sh
+  make dev
+  ```
 - **page**: Build the page using local environment. Dependencies: npm, node
   ```sh
   make page


### PR DESCRIPTION
## Summary
Core Dev Container for the milestone — a one-command, reproducible local environment built on the #23 Node 22 + Playwright foundation.

## What
`.devcontainer/devcontainer.json`:
- Base **`node:22-bookworm`** (matches prod).
- Features: **docker-outside-of-docker** (so `make lint` / `make build` / `make dev-build` work in-container) + **Python 3.12** (spec-kit prereq).
- `postCreate`: `npm ci` → `playwright install --with-deps chromium` (arch-native pinned browser) → `pip install uv`.
- `forwardPorts: [8080]` for the `npm start` live-server preview.
- Runs as **`root`** — see trade-off below.
- README: a "Dev Container" pointer + the root/Docker-socket note.

## Decisions / trade-offs
- **Runs as root.** On Apple Silicon the bind-mounted workspace is owned by host uid `501`, but the container's non-root `node` user is `1000`, so it can't write `dist/` / `node_modules` (this silently broke `postCreate`). Running as root sidesteps the uid mismatch cleanly and cross-platform. Cost: container code (and any agent) has host Docker access via the mounted socket. Documented in the README.
- **Python + uv are installed but the *build* doesn't use them** — they're the prerequisite for spec-kit (#21).

## Verified (in-container)
- `node v22.22.3`, `python 3.12.13`, `docker 29.6.1`, `uv 0.11.26` all present.
- The exact `postCreate` runs clean; **`make page` → valid PDF (`%PDF-1.4`)**; **`npm start` → "Serving 'dist' at http://127.0.0.1:8080"**.
- Note: `devcontainer up --remove-existing-container` hung once (a Docker Desktop hiccup, unrelated to the config); verified via `devcontainer exec` against the built container.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)