### PR TITLE
Agentic tooling: permission allowlist + gh/Claude Code CLIs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,11 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(gh run watch *)",
+      "Bash(make --dry-run *)",
+      "Bash(make lint-fast)"
+    ]
+  },
   "hooks": {
     "Stop": [
       {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"
-    }
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "forwardPorts": [
     8080
@@ -34,6 +35,6 @@
       }
     }
   },
-  "postCreateCommand": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci && npx --yes playwright install --with-deps chromium && pip install --root-user-action=ignore uv && { UV_TOOL_BIN_DIR=/usr/local/bin uv tool install --from git+https://github.com/github/spec-kit.git specify-cli || echo 'WARN: spec-kit install failed (non-fatal); install later with: uv tool install --from git+https://github.com/github/spec-kit.git specify-cli'; }",
+  "postCreateCommand": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci && npx --yes playwright install --with-deps chromium && pip install --root-user-action=ignore uv && { UV_TOOL_BIN_DIR=/usr/local/bin uv tool install --from git+https://github.com/github/spec-kit.git specify-cli || echo 'WARN: spec-kit install failed (non-fatal); install later with: uv tool install --from git+https://github.com/github/spec-kit.git specify-cli'; } && { npm install -g @anthropic-ai/claude-code || echo 'WARN: Claude Code CLI install failed (non-fatal)'; }",
   "remoteUser": "root"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,10 @@ task not wrapped by a target is the local watch dev server (`npm start`).
 
 - **Dev Container (recommended)** — `make dev` (or VS Code "Reopen in Container") opens
   `.devcontainer/`, a reproducible environment with Node 22, the Playwright Chromium, Docker access,
-  Python + uv, and the spec-kit `specify` CLI; every target below works inside it. It runs as `root`
-  with host Docker access.
+  Python + uv, the spec-kit `specify` CLI, and the `gh` + Claude Code CLIs; every target below works
+  inside it. It runs as `root` with host Docker access, and `.claude/settings.json` pre-approves
+  common read-only commands (`gh run watch`, `make --dry-run`, `make lint-fast`) to cut agent
+  permission prompts.
 - `npm start` — build + watch + live-server dev server (needs node/npm locally).
 - `make page` — one-off local build into `dist/` (needs node/npm).
 - `make dev-build` — dockerized build that copies output into local `dist/` (no local node needed).


### PR DESCRIPTION
## Summary
Rounds out the milestone's agentic tooling. Much was already seeded (the `.claude/settings.json` Stop hook from #25, the `specify` CLI and editor extensions in #21/#28); this adds the permission allowlist and the remaining CLIs. Closes #20.

## What
- **`.claude/settings.json`** — a permission allowlist (`gh run watch *`, `make --dry-run *`, `make lint-fast`) so agents hit fewer prompts on common **read-only** commands. Mutating commands (`git push`, `gh pr create`, `docker`, `npm ci`) intentionally still prompt — this is a committed, all-contributors file. The Stop hook (self-review gate) is preserved.
- **`.devcontainer`** — add the **github-cli** feature and install the **Claude Code CLI** in `postCreate` (non-fatal, matching the `specify` pattern).
- **AGENTS.md** — the Dev Container bullet now lists the `gh` + Claude Code CLIs and notes the pre-approved allowlist.

## Notes
- Allowlist is **read-only only**, derived from actual session usage (via the fewer-permission-prompts skill). Most of what I run is already auto-allowed by Claude Code (`git status/log/diff`, `gh pr view/checks`, `jq`, …) so needs no entry.
- The ` *` patterns are the documented prefix form; commands are read-only and Claude Code evaluates compound/chained commands per-segment, so a chained mutating command still prompts.

## Verified
- `.claude/settings.json` valid JSON; Stop hook intact; devcontainer valid JSON with 3 features + both CLIs.
- Rebased onto main after #28 merged (brought in `lint-fast` + editor extensions); resolved the devcontainer.json conflict keeping both the `customizations` block and the specify+claude-code `postCreate`.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)