### PR TITLE
Document local development (docs/local-development.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,9 @@ with a clear imperative title, a type label (`documentation` / `enhancement` / `
 
 ## Spec-driven development
 
-Non-trivial features are developed spec-first with spec-kit: `/speckit-specify` → `/speckit-plan` →
-`/speckit-tasks` → `/speckit-implement` (skills under `.claude/skills/`). The spec lives in
-`specs/<feature>/` as the source of intent; the project constitution is
+Non-trivial features are developed spec-first with spec-kit: `/speckit-specify` → `/speckit-clarify`
+→ `/speckit-plan` → `/speckit-tasks` → `/speckit-implement` (skills under `.claude/skills/`). The
+spec lives in `specs/<feature>/` as the source of intent; the project constitution is
 `.specify/memory/constitution.md`. See [`docs/spec-driven.md`](docs/spec-driven.md).
 
 ## Required Skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ task not wrapped by a target is the local watch dev server (`npm start`).
   Python + uv, the spec-kit `specify` CLI, and the `gh` + Claude Code CLIs; every target below works
   inside it. It runs as `root` with host Docker access, and `.claude/settings.json` pre-approves
   common read-only commands (`gh run watch`, `make --dry-run`, `make lint-fast`) to cut agent
-  permission prompts.
+  permission prompts. Full guide: [`docs/local-development.md`](docs/local-development.md).
 - `npm start` — build + watch + live-server dev server (needs node/npm locally).
 - `make page` — one-off local build into `dist/` (needs node/npm).
 - `make dev-build` — dockerized build that copies output into local `dist/` (no local node needed).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The Curriculum Vitae
 
 [![Super-Linter](https://github.com/brunogbv/cv/actions/workflows/superlinter.yml/badge.svg)](https://github.com/marketplace/actions/super-linter)
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/brunogbv/cv)
 
 Hosted at: [https://valerio.dev](https://valerio.dev)
 
@@ -22,6 +23,7 @@ You are a fantastic developer. Keep your CV on GitHub, exploiting Node.js GitHub
 
 Developer documentation lives in [`docs/`](docs/):
 
+- [Local development](docs/local-development.md) — set up the Dev Container, everyday commands, and the change workflow (start here).
 - [Architecture](docs/architecture.md) — code structure, the build pipeline, the content data model, and how the site is served.
 - [CI/CD](docs/ci-cd.md) — GitHub Actions workflows and the manual Docker-based deployment.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ agent-oriented quick reference, see [`AGENTS.md`](../AGENTS.md).
 
 ## Contents
 
+- **[Local development](local-development.md)** — set up the Dev Container, everyday commands, and
+  the change workflow (the entry point for working on this repo).
 - **[Architecture](architecture.md)** — code structure, the build pipeline, the content data
   model, and how the site is served.
 - **[CI/CD](ci-cd.md)** — GitHub Actions workflows and the (manual) Docker-based deployment.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -36,8 +36,9 @@ Edit CV **content** in `src/metadata/metadata.js`. For the architecture and buil
 ## Working on a change
 
 1. **Raise an issue** and branch — see [contributing.md](contributing.md).
-2. For a non-trivial feature, go **spec-first** with spec-kit (`/speckit-specify` → `/speckit-plan`
-   → `/speckit-tasks` → `/speckit-implement`) — see [spec-driven.md](spec-driven.md).
+2. For a non-trivial feature, go **spec-first** with spec-kit (`/speckit-specify` →
+   `/speckit-clarify` → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`) — see
+   [spec-driven.md](spec-driven.md).
 3. **Self-review** any change over 10 lines with `/code-review` before opening a PR (enforced by a
    Stop hook); validate locally with `make lint-fast` / `make lint`.
 4. Open a PR that links its issue (`Closes #<n>`), keep docs in sync in the same PR, and record

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,46 @@
+# Local development
+
+The fastest way to work on this repo is the **Dev Container** — a reproducible environment with
+everything preinstalled. This is the entry point; it links to the detailed docs.
+
+## Open in a Dev Container (recommended)
+
+Open the repo in its [Dev Container](../.devcontainer/devcontainer.json):
+
+- **VS Code** — "Dev Containers: Reopen in Container" (needs the Dev Containers extension), or
+- **CLI** — `make dev` (wraps `devcontainer up`; needs the devcontainer CLI).
+
+You get Node 22, the Playwright Chromium (for the PDF), Docker access, Python + uv, the spec-kit
+`specify` CLI, the `gh` + Claude Code CLIs, and editor extensions for the CI linters. It runs as
+`root` with host Docker access, and `.claude/settings.json` pre-approves common read-only commands
+so agents hit fewer permission prompts.
+
+> Without a Dev Container you can build with just Node + npm (`npm ci`), but you'll also need a
+> Chromium for the PDF and Docker for `make lint` / `make build`. The container is the supported path.
+
+## Everyday commands
+
+Everything goes through the `Makefile` — run `make <target>`:
+
+| Task | Command | Notes |
+| ---- | ------- | ----- |
+| Preview (build + watch + serve) | `npm start` | serves `dist/` on port 8080 |
+| One-off build (HTML + PDF) | `make page` | writes to `dist/` |
+| Fast lint (inner loop) | `make lint-fast` | native JS + Markdown; approximates CI |
+| Full lint (CI parity) | `make lint` | the Super-Linter image; the authoritative gate |
+| Dockerized build | `make build` / `make dev-build` | into the shared volume / copied to `dist/` |
+
+Edit CV **content** in `src/metadata/metadata.js`. For the architecture and build pipeline see
+[architecture.md](architecture.md); for CI and deployment see [ci-cd.md](ci-cd.md).
+
+## Working on a change
+
+1. **Raise an issue** and branch — see [contributing.md](contributing.md).
+2. For a non-trivial feature, go **spec-first** with spec-kit (`/speckit-specify` → `/speckit-plan`
+   → `/speckit-tasks` → `/speckit-implement`) — see [spec-driven.md](spec-driven.md).
+3. **Self-review** any change over 10 lines with `/code-review` before opening a PR (enforced by a
+   Stop hook); validate locally with `make lint-fast` / `make lint`.
+4. Open a PR that links its issue (`Closes #<n>`), keep docs in sync in the same PR, and record
+   significant decisions as an [ADR](adr/).
+
+See [`AGENTS.md`](../AGENTS.md) for the full set of conventions.

--- a/docs/spec-driven.md
+++ b/docs/spec-driven.md
@@ -11,13 +11,16 @@ Run these `/speckit-*` skills in Claude Code (installed under `.claude/skills/`)
 1. `/speckit-constitution` — establish or amend the project principles
    (`.specify/memory/constitution.md`).
 2. `/speckit-specify` — turn a feature description into a spec (`specs/<feature>/spec.md`).
-3. `/speckit-plan` — produce the technical implementation plan.
-4. `/speckit-tasks` — break the plan into actionable tasks.
-5. `/speckit-implement` — execute the tasks.
+3. `/speckit-clarify` — resolve ambiguities in the spec before planning (recommended; skip only
+   when the spec is already unambiguous). It asks up to 5 targeted questions and records the
+   answers back into the spec.
+4. `/speckit-plan` — produce the technical implementation plan.
+5. `/speckit-tasks` — break the plan into actionable tasks.
+6. `/speckit-implement` — execute the tasks.
 
-Optional quality steps: `/speckit-clarify` (de-risk ambiguity before planning), `/speckit-analyze`
-(cross-artifact consistency), `/speckit-checklist` (requirements checklists), and `/speckit-converge`
-(assess the codebase and append remaining work).
+Optional quality steps: `/speckit-analyze` (read-only spec↔plan↔tasks consistency check, run after
+`/speckit-tasks` and before `/speckit-implement`), `/speckit-checklist` (requirements checklists),
+and `/speckit-converge` (assess the codebase and append remaining work).
 
 ## How it ties into our conventions
 


### PR DESCRIPTION
## Summary
The last piece of the **Local development with devcontainers** milestone — a consolidated local-dev guide that ties the whole story together and links to the detailed docs (no duplication). Closes #22.

## What
- **`docs/local-development.md`** (new) — the entry point:
  - Open in the Dev Container (`make dev` / VS Code "Reopen in Container") + what it provides.
  - Everyday commands table (`npm start` preview on :8080, `make page`, `make lint-fast`, `make lint`, `make build`/`dev-build`).
  - The change workflow: issue → spec-kit (`/speckit-*`) → self-review (`/code-review`) → PR (`Closes #`).
- **README** — an "Open in Dev Containers" badge + "Local development" in the docs list.
- **docs/README** — "Local development" as the entry-point index item.
- **AGENTS.md** — the Dev Container bullet cross-links the guide.
- **Spec-kit flow consistency** — promote `/speckit-clarify` into the documented workflow (a numbered step between `specify` and `plan`) across `AGENTS.md`, `docs/spec-driven.md`, and `docs/local-development.md`, which previously disagreed (two omitted it, one filed it "optional") — the clarify skill is expected to run *before* `/speckit-plan`. Also sharpened the `/speckit-analyze` description (read-only spec↔plan↔tasks check, run after `tasks` / before `implement`); it stays an optional step.

## Verified
- `make lint-fast` clean (11 docs, 0 errors).
- Self-reviewed for accuracy: every documented command matches `Makefile`/`package.json`, container-contents claims match `.devcontainer`/`.claude/settings.json`, and all relative links + the badge target resolve.
- Second self-review round on the spec-kit changes: fan-out reviewers confirmed `clarify`'s description/ordering match the skill, and caught a stale 4-step arrow in `local-development.md` (now fixed) so all three docs agree.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
