### PR TITLE
Upgrade actions/checkout to v5 to drop deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # super-linter needs the full git history to get the
           # list of files that changed across commits


### PR DESCRIPTION
## Summary
Bump `actions/checkout@v4` → `@v5` in the Lint workflow. v4 targets the deprecated Node 20 runtime; GitHub was force-running it on Node 24 and annotating every CI run. v5 is Node 24-native and clears the warning.

## Scope
- One line: `.github/workflows/superlinter.yml:17`.
- `super-linter@v6.7.0` untouched — it runs in Docker (not on the runner's Node) and is release-please-managed.

## Verified
- CI run on this branch passes and no longer shows the "Node.js 20 is deprecated" annotation.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)