### PR TITLE
Sync constitution workflow with AGENTS.md: add /speckit-clarify

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -37,13 +37,13 @@ config.
 ## Development Workflow
 
 Work is tracked in GitHub (Issues, Milestones, Projects). Non-trivial features are spec-driven:
-`/speckit-specify` → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`, with the spec living
-in `specs/<feature>/` as the source of intent. Every change lands via a branch and a PR that links
-its issue with `Closes #<n>`.
+`/speckit-specify` → `/speckit-clarify` → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`,
+with the spec living in `specs/<feature>/` as the source of intent. Every change lands via a branch
+and a PR that links its issue with `Closes #<n>`.
 
 ## Governance
 
 This constitution reflects and defers to [`AGENTS.md`](../../AGENTS.md); amendments update both and
 keep them consistent. All PRs are expected to comply, and added complexity must be justified.
 
-**Version**: 1.0.0 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-01
+**Version**: 1.0.1 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-01


### PR DESCRIPTION
## Summary
The project constitution's Development Workflow omitted `/speckit-clarify`, which we promoted into the spec-driven flow in `AGENTS.md` and `docs/spec-driven.md`. The constitution's Governance clause requires it to stay consistent with `AGENTS.md`, so this aligns it.

## Change
- `.specify/memory/constitution.md`: workflow line now `specify → clarify → plan → tasks → implement` (matches AGENTS.md); version `1.0.0 → 1.0.1`.
- `/speckit-analyze` remains intentionally out of the core arrow (optional step, documented in `docs/spec-driven.md`).

## Verified
- One-line consistency fix (under the self-review threshold).
- `.specify/` is excluded from Super-Linter, so no lint impact; CI lint stays green.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)