### PR TITLE
Align issue-tracking conventions: one milestone per shippable thing, labels for phases, projects optional

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -36,7 +36,8 @@ config.
 
 ## Development Workflow
 
-Work is tracked in GitHub (Issues, Milestones, Projects). Non-trivial features are spec-driven:
+Work is tracked in GitHub — one Milestone per shippable deliverable, its Issues tagged with
+type/phase labels for grouping; Projects are optional. Non-trivial features are spec-driven:
 `/speckit-specify` → `/speckit-clarify` → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`,
 with the spec living in `specs/<feature>/` as the source of intent. Every change lands via a branch
 and a PR that links its issue with `Closes #<n>`.
@@ -46,4 +47,4 @@ and a PR that links its issue with `Closes #<n>`.
 This constitution reflects and defers to [`AGENTS.md`](../../AGENTS.md); amendments update both and
 keep them consistent. All PRs are expected to comply, and added complexity must be justified.
 
-**Version**: 1.0.1 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-01
+**Version**: 1.0.2 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-02

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,14 @@ significant, expensive-to-reverse decisions as an ADR in [`docs/adr/`](docs/adr/
 
 ## Issue Tracking
 
-Work is tracked in **GitHub Issues, Milestones, and Projects** — see
+Work is tracked in **GitHub Issues and Milestones** (Projects optional) — see
 [`docs/contributing.md`](docs/contributing.md). Before starting non-trivial work, raise an issue
 with a clear imperative title, a type label (`documentation` / `enhancement` / `bug` /
 `maintenance`), and a body covering **Context**, an **Acceptance criteria** checklist, and
-**References**. Group related issues under a milestone, and link PRs to issues with `Closes #<n>`.
+**References**. Use **one milestone per shippable thing** (a deliverable/initiative) and **labels to
+tag phases** (e.g. `phase:*`) for grouping within it — not a milestone per phase. A GitHub **Project
+is optional** (a board/field view; use it for kanban/custom-field/cross-milestone tracking). Link
+PRs to issues with `Closes #<n>`.
 
 ## Spec-driven development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ agent-oriented quick reference, see [`AGENTS.md`](../AGENTS.md).
   model, and how the site is served.
 - **[CI/CD](ci-cd.md)** — GitHub Actions workflows and the (manual) Docker-based deployment.
 - **[Contributing & Issue Tracking](contributing.md)** — how work is tracked in GitHub (issues,
-  milestones, projects) and how to raise a well-formed issue.
+  milestones, labels; projects optional) and how to raise a well-formed issue.
 - **[Architecture Decision Records](adr/)** — significant technical decisions and their rationale.
 - **[Spec-driven development](spec-driven.md)** — the spec-kit `/speckit-*` workflow for non-trivial features.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,15 +1,44 @@
 # Contributing & Issue Tracking
 
-All work on this repo is tracked in **GitHub** — Issues, Milestones, and Projects. Open an issue
-before starting non-trivial work so the change is visible, reviewable, and linked to its goal.
+All work on this repo is tracked in **GitHub** — Issues and Milestones, with labels for grouping and
+an optional Project board. Open an issue before starting non-trivial work so the change is visible,
+reviewable, and linked to its goal.
 
 ## Where work lives
 
 | Tool         | Purpose                                                                          |
 | ------------ | -------------------------------------------------------------------------------- |
 | Issues       | One unit of work — a bug, feature, doc change, or chore.                          |
-| Milestones   | Group related issues that together deliver a goal (e.g. "Set up Claude Code for this repo"). |
-| Projects     | Board view for status (Todo / In progress / Done).                                |
+| Milestones   | **One per shippable thing** — a coherent deliverable/initiative. Groups the issues that deliver it; the progress bar tracks "is this thing done?". Not per-phase or per-task. |
+| Labels       | Tag cross-cutting dimensions (**type**, and a **phase**/story label for multi-phase work) so issues filter and group *within or across* milestones — without minting more milestones. |
+| Projects     | **Optional** board/field view (kanban, custom fields, cross-milestone). See [Milestones, labels, and projects](#milestones-labels-and-projects). |
+
+## Milestones, labels, and projects
+
+The pattern to follow:
+
+- **Milestone = one per shippable thing.** A milestone is a coherent deliverable whose completion is
+  meaningful on its own — an initiative or a release increment (e.g. "Local development with
+  devcontainers", "Migrate hosting & CD to Vercel"). Put every issue that makes up that deliverable
+  under it, so the milestone's progress bar answers "how close is this thing to done?". **Don't**
+  create a milestone per phase or per task — that fragments the one signal you care about and adds
+  ceremony. A one-off issue that isn't part of a larger deliverable needs no milestone.
+- **Labels = tag the cross-cutting dimensions.** Beyond the required **type** label, use a **phase**
+  (or story) label for multi-phase work — e.g. a spec-kit feature uses `phase:foundational`,
+  `phase:us1`, … . Labels let you group and filter (e.g. "all `phase:us1` issues in this milestone")
+  **without** minting extra milestones. This is how you get per-phase visibility while keeping one
+  milestone.
+- **Projects = optional.** A GitHub Project is a board/table view over issues and PRs with custom
+  fields and saved views. It groups *issues* (via fields/views), **not** milestones.
+  - **Consider one when** you want a visual **status board** (Todo / In progress / Done) or
+    roadmap/timeline; **custom fields** beyond labels (a "Phase" or "Priority" select, iteration
+    dates); to **aggregate across multiple milestones or repos**; or when there are enough concurrent
+    issues that the flat list is unwieldy.
+  - **Skip it when** it's a small, single-repo effort tracked by one or two people — a milestone +
+    labels + the issues list already answers "what's left / what's in flight", and a Project is just
+    another surface that can drift out of sync. (For phase visibility specifically, a Project's
+    "Phase" field and `phase:*` labels do the same job — you don't need a Project *and* per-phase
+    milestones.)
 
 ## Raising an issue
 
@@ -35,8 +64,11 @@ A well-formed issue has:
    - Links to related files, issues, PRs, or docs
    ```
 
-4. **Milestone** — assign it when the issue is part of a larger effort.
-5. **Project** — add it to the board so status is tracked.
+4. **Milestone** *(if applicable)* — assign it only when the issue is part of a larger shippable
+   deliverable (see [above](#milestones-labels-and-projects)); a standalone change needs none.
+5. **Grouping label** *(if applicable)* — for multi-phase work, add a `phase:*` (or story) label so
+   the issue groups without a new milestone.
+6. **Project** *(optional)* — add it to a board only if the effort uses one.
 
 ## Linking pull requests
 
@@ -84,6 +116,13 @@ Create a milestone (no native `gh` subcommand — use the REST API):
 
 ```sh
 gh api --method POST repos/{owner}/{repo}/milestones -f title="Set up Claude Code for this repo"
+```
+
+Create and attach a grouping label (for multi-phase work):
+
+```sh
+gh label create "phase:foundational" --color c5def5 --description "Feature phase"
+gh issue edit 42 --add-label phase:foundational
 ```
 
 List work:

--- a/docs/spec-driven.md
+++ b/docs/spec-driven.md
@@ -25,7 +25,8 @@ and `/speckit-converge` (assess the codebase and append remaining work).
 ## How it ties into our conventions
 
 - **Issues** — `/speckit-taskstoissues` turns the generated tasks into GitHub issues; keep them
-  under the feature's milestone (see [contributing.md](contributing.md)).
+  under the feature's single milestone and tag phases with `phase:*` labels for grouping (see
+  [contributing.md](contributing.md)).
 - **PRs** — implement on a branch and link the issue with `Closes #<n>`.
 - **Self-review** — the ">10 reviewable lines → `/code-review`" gate still applies to spec-driven
   changes.


### PR DESCRIPTION
## Summary
Make the harness docs practice the tracking pattern we aligned on while planning the Vercel migration, and fix a place that contradicted it.

## Pattern documented
- **One milestone per shippable thing** (a deliverable/initiative) — not per phase or per task.
- **Labels** tag cross-cutting dimensions (type + a `phase:*`/story label) to group issues within/across milestones without minting more.
- **GitHub Projects are optional** — a board/field view over *issues* (not a milestone grouper), with explicit pros/cons and when-to-use / when-to-skip.

## Changes
- `docs/contributing.md` (canonical): new **Milestones, labels, and projects** section; updated "Where work lives" table; issue-raising steps now make milestone/labels conditional and Project optional (was: "add it to the board so status is tracked"); added a phase-label `gh` snippet.
- `AGENTS.md`: Issue Tracking section aligned + concise.
- `.specify/memory/constitution.md`: Development Workflow line aligned; version `1.0.1 → 1.0.2` (governance requires constitution + AGENTS.md to stay consistent — both updated).
- `docs/spec-driven.md`: `taskstoissues` note → single milestone + `phase:*` labels.
- `docs/README.md`: docs index line.

## Verified
- `make lint-fast` clean; anchor link resolves; no leftover "projects mandatory" phrasing.
- Independent cross-file consistency review — no findings.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)