### PR TITLE
Vercel migration: planning baseline (spec, plan, tasks)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,1 @@
+{"feature_directory":"specs/001-vercel-cd-migration"}

--- a/specs/001-vercel-cd-migration/checklists/requirements.md
+++ b/specs/001-vercel-cd-migration/checklists/requirements.md
@@ -13,7 +13,7 @@
 
 ## Requirement Completeness
 
-- [ ] No [NEEDS CLARIFICATION] markers remain
+- [x] No [NEEDS CLARIFICATION] markers remain
 - [x] Requirements are testable and unambiguous
 - [x] Success criteria are measurable
 - [x] Success criteria are technology-agnostic (no implementation details)
@@ -31,15 +31,15 @@
 
 ## Notes
 
-- **3 `[NEEDS CLARIFICATION]` markers remain by design** — they are the owner-level decisions this
-  spec deliberately leaves open for the next phase, `/speckit-clarify`:
-  1. **FR-007** — canonical domain + redirect direction (apex `valerio.dev` vs `www`).
-  2. **FR-010** — whether retiring the manual VM/nginx/certbot stack + decommissioning the VM is
-     part of THIS initiative (final phase, post-cutover) or a separate follow-up.
-  3. **FR-012** — rollback retention window (how long the VM stays live/reversible after cutover).
+- **All 3 `[NEEDS CLARIFICATION]` markers resolved** in the `/speckit-clarify` session (2026-07-01):
+  1. **FR-007** — canonical host is `valerio.dev` (apex); `www` issues a permanent 301 redirect.
+  2. **FR-010** — stack retirement + VM decommission is in scope, as the final phase after the
+     cutover is verified.
+  3. Rollback window (formerly FR-012) — **no rollback needed**: the site is not currently live and
+     the VM is already down, so downtime/rollback provisions were removed and FR-009 rewritten.
+     FR-012 now covers cache freshness.
 - **"Implementation details" note**: the requirements themselves are platform-agnostic (they say
   "the platform"). The target platform (**Vercel**) is named only in the verbatim **Input** and in
   **Assumptions** as context the user supplied, not embedded in the requirements. The *how* of PDF
   rendering in the platform build is explicitly deferred to `/speckit-plan`.
-- All other checklist items pass. The spec is ready to proceed to `/speckit-clarify` (recommended,
-  to resolve the 3 markers) and then `/speckit-plan`.
+- All checklist items now pass. The spec is ready to proceed to `/speckit-plan`.

--- a/specs/001-vercel-cd-migration/checklists/requirements.md
+++ b/specs/001-vercel-cd-migration/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: Migrate hosting & CD to Vercel
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **3 `[NEEDS CLARIFICATION]` markers remain by design** — they are the owner-level decisions this
+  spec deliberately leaves open for the next phase, `/speckit-clarify`:
+  1. **FR-007** — canonical domain + redirect direction (apex `valerio.dev` vs `www`).
+  2. **FR-010** — whether retiring the manual VM/nginx/certbot stack + decommissioning the VM is
+     part of THIS initiative (final phase, post-cutover) or a separate follow-up.
+  3. **FR-012** — rollback retention window (how long the VM stays live/reversible after cutover).
+- **"Implementation details" note**: the requirements themselves are platform-agnostic (they say
+  "the platform"). The target platform (**Vercel**) is named only in the verbatim **Input** and in
+  **Assumptions** as context the user supplied, not embedded in the requirements. The *how* of PDF
+  rendering in the platform build is explicitly deferred to `/speckit-plan`.
+- All other checklist items pass. The spec is ready to proceed to `/speckit-clarify` (recommended,
+  to resolve the 3 markers) and then `/speckit-plan`.

--- a/specs/001-vercel-cd-migration/contracts/deploy-contract.md
+++ b/specs/001-vercel-cd-migration/contracts/deploy-contract.md
@@ -1,0 +1,50 @@
+# Contract: CI → Vercel deploy interface
+
+The GitHub Actions workflow (`.github/workflows/deploy.yml`) is the sole deploy path. Vercel's own
+git build is disabled.
+
+## Triggers → environment
+
+| Trigger | Environment | Vercel CLI |
+|---------|-------------|------------|
+| `push` to `main` | production | `vercel pull --environment=production` → `vercel build --prod` → `vercel deploy --prebuilt --prod` |
+| `pull_request` | preview | `vercel pull --environment=preview` → `vercel build` → `vercel deploy --prebuilt` |
+
+## Steps (both environments)
+
+1. `actions/checkout`
+2. `actions/setup-node` (Node 22) + `npm ci`
+3. Restore/save cache of `~/.cache/ms-playwright` keyed on the resolved Playwright version **and**
+   the runner OS (browser binaries only)
+4. `npx playwright install --with-deps chromium` — the pinned Chromium (parity-critical). Note
+   `--with-deps` reinstalls apt system libraries every run (not covered by the step-3 cache)
+5. `make page` — build `dist/` incl. the PDF
+6. `make deploy` (with `--prod` on `main`) — see below
+7. Capture the deploy URL from `make deploy` / CLI stdout and post it to the PR
+
+## `make deploy` (Principle I — the deploy command lives in the Makefile)
+
+`make deploy` encapsulates the Vercel CLI sequence so CI does not call `vercel` ad hoc:
+`vercel pull` → `vercel build` → `vercel deploy --prebuilt`, reading `VERCEL_TOKEN`/`VERCEL_ORG_ID`/
+`VERCEL_PROJECT_ID` from the environment. Production vs preview is selected by a variable
+(e.g. `make deploy PROD=1` adds `--prod` and `--environment=production`). Because `vercel.json` sets
+`framework: null` + `buildCommand: ""`, the `vercel build` inside `make deploy` **packages the
+already-built `dist/`** rather than re-running `node src/build.js`.
+
+## Inputs
+
+- Secrets: `VERCEL_TOKEN`; env: `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
+
+## Outputs / observable behavior
+
+- **Preview** (PR): a unique preview URL, posted back to the PR as a comment / job summary (the
+  Vercel bot does **not** auto-comment in a CLI-only setup — the workflow must surface it). Satisfies
+  FR-002.
+- **Production** (`main`): the deployment is aliased to `valerio.dev`. Satisfies FR-001.
+
+## Failure semantics
+
+- If `make page` fails (incl. PDF render error) the job fails **before** any deploy → nothing is
+  published; the last good production deployment keeps serving (FR-008).
+- The build MUST NOT depend on external CDN availability (FR-003) — fonts/CSS are vendored, so step
+  5 succeeds with no external network to font/CSS CDNs (verified in quickstart).

--- a/specs/001-vercel-cd-migration/contracts/serving-contract.md
+++ b/specs/001-vercel-cd-migration/contracts/serving-contract.md
@@ -1,0 +1,82 @@
+# Contract: HTTP serving surface
+
+What the production domain exposes once cut over to Vercel. Verifiable with `curl -sI`.
+
+## Routes
+
+| Request | Response |
+|---------|----------|
+| `GET /` | `200`, `text/html` — the CV page |
+| `GET /<slug>.pdf` | `200`, `application/pdf` — the CV PDF (existing filename preserved, FR-005) |
+| `GET /assets/*` | `200`, correct content-type — static assets |
+| `GET /index.html` | `308` → `/` (cleanUrls) |
+| `GET /<path>/` | `308` → `/<path>` (trailingSlash=false) |
+| `GET /<unknown>` | `404` (Vercel default not-found) |
+
+## Host + scheme redirects
+
+| From | To | Code |
+|------|-----|------|
+| `http://valerio.dev/*` | `https://valerio.dev/*` | `308` (Vercel automatic HTTPS) |
+| `https://www.valerio.dev/*` | `https://valerio.dev/*` | `301` (Vercel domain redirect) |
+
+## Headers (`Cache-Control` + security)
+
+| Path glob | Configured `Cache-Control` (in `vercel.json`) |
+|-----------|-----------------|
+| `/` (HTML) | `public, max-age=0, s-maxage=86400, stale-while-revalidate=86400` |
+| `*.pdf` | `public, max-age=0, s-maxage=86400, stale-while-revalidate=86400` |
+| `*.{css,js,png,jpg,jpeg,svg,webp,ico,woff,woff2}` | `public, max-age=0, s-maxage=31536000, stale-while-revalidate=86400` |
+| `/(.*)` | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin` |
+
+> **Client vs edge**: when only `Cache-Control` is set, Vercel **strips `s-maxage` and
+> `stale-while-revalidate` before responding to the client** — they govern the edge/CDN only. So
+> `curl -sI` observes `public, max-age=0, must-revalidate` for HTML/PDF/assets, while the edge still
+> caches per `s-maxage`. Verify the *client* value (`max-age=0`) with curl; edge caching is an
+> internal behavior. (If an asset's edge TTL ever needs to be client-visible, use
+> `CDN-Cache-Control`, which Vercel forwards.)
+
+Freshness invariant (FR-012): a new deployment invalidates the edge cache, and the client-facing
+`max-age=0` forces browser revalidation — so an updated page/PDF is visible promptly; unhashed
+assets are edge-cached but browser-revalidated (no `immutable`, since asset filenames are
+stable/unhashed).
+
+## TLS
+
+Valid, auto-renewing certificate for `valerio.dev` and `www.valerio.dev` (FR-006). No manual
+issuance/renewal.
+
+## Reference `vercel.json`
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "",
+  "outputDirectory": "dist",
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "git": { "deploymentEnabled": false },
+  "headers": [
+    { "source": "/", "headers": [
+      { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=86400, stale-while-revalidate=86400" } ] },
+    { "source": "/(.*)\\.pdf", "headers": [
+      { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=86400, stale-while-revalidate=86400" } ] },
+    { "source": "/(.*)\\.(css|js|png|jpg|jpeg|svg|webp|ico|woff|woff2)", "headers": [
+      { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=31536000, stale-while-revalidate=86400" } ] },
+    { "source": "/(.*)", "headers": [
+      { "key": "X-Content-Type-Options", "value": "nosniff" },
+      { "key": "X-Frame-Options", "value": "DENY" },
+      { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" } ] }
+  ]
+}
+```
+
+`framework: null` + `buildCommand: ""` are required so `vercel build` in CI **packages the
+already-built `dist/`** (produced by `make page`) instead of auto-detecting the `build` npm script
+and re-running `node src/build.js` (which would launch Chromium again). The apex↔www redirect is
+configured in Vercel Domain settings, **not** here (path-based `redirects` cannot match by host).
+
+**Out of scope (accepted defaults)**: unknown paths serve Vercel's generic 404 (no custom `404.html`
+is planned); no `robots.txt`/`sitemap.xml` is added. Call these out later if the public CV wants a
+branded 404 — no spec requirement covers them.

--- a/specs/001-vercel-cd-migration/data-model.md
+++ b/specs/001-vercel-cd-migration/data-model.md
@@ -1,0 +1,63 @@
+# Phase 1 Data Model: Migrate hosting & CD to Vercel
+
+This feature is infrastructure, not application data — the "entities" are configuration and
+deployment objects. Captured here so tasks and contracts have a shared vocabulary.
+
+## Build output (`dist/`)
+
+The artifact produced by `make page` (`node src/build.js`) and uploaded to Vercel.
+
+| Field | Description | Validation |
+|-------|-------------|------------|
+| `index.html` | Rendered CV page | MUST exist; references only **local** assets (no CDN URLs) |
+| `<slug>.pdf` | Rendered PDF (`<name>.<title>.pdf` via `speakingurl`) | MUST exist, be non-empty, embed the vendored fonts (no fallback fonts) |
+| `assets/` | Copied `src/assets/` incl. `assets/vendor/` (fonts + CSS) | Vendored Roboto, Bootstrap 5.2.0, Font Awesome 6.1.2 present |
+| `assets/*` (favicons, `photo.jpg`, `styles.css`, QR) | Existing assets | Unchanged |
+
+Invariant: a deployment is only valid if **both** `index.html` and the PDF are present and
+correctly fonted (FR-004). The build MUST fail loudly if PDF rendering fails (no partial output).
+
+## Deployment
+
+A single build published to Vercel.
+
+| Field | Values |
+|-------|--------|
+| `environment` | `production` (from `main`) \| `preview` (from a PR) |
+| `sourceRef` | git SHA / branch |
+| `url` | Vercel deployment URL (preview: unique `*.vercel.app`; production: aliased to `valerio.dev`) |
+| `state` | `queued` → `building`(in CI) → `uploading` → `ready` \| `error` |
+
+State rules: a build/PDF failure ends in `error` and is **not** promoted; the last `ready`
+production deployment keeps serving (FR-008). Production `--prod` aliases the deployment to the
+canonical domain.
+
+## Domain
+
+| Host | Role | DNS record (owner-run) | Redirect |
+|------|------|------------------------|----------|
+| `valerio.dev` | **canonical** | `A → <IP from Vercel dashboard>` (`76.76.21.21` legacy default) | — (serves) |
+| `www.valerio.dev` | redirect | `CNAME → <project>.vercel-dns-###.com` | `301 → https://valerio.dev` |
+
+TLS: Vercel auto-provisions and renews Let's Encrypt certificates for both hosts once DNS verifies
+(replaces certbot). Records are exact-valued from the Vercel dashboard.
+
+## Vercel project configuration (`vercel.json` + dashboard)
+
+| Setting | Value | Where |
+|---------|-------|-------|
+| `outputDirectory` | `dist` | `vercel.json` |
+| `framework` / `buildCommand` | `null` / `""` — so `vercel build` packages the prebuilt `dist/` instead of re-running `node src/build.js` | `vercel.json` |
+| `git.deploymentEnabled` | `false` | `vercel.json` |
+| `cleanUrls` / `trailingSlash` | `true` / `false` | `vercel.json` |
+| `Cache-Control` + security headers | per content type | `vercel.json` `headers` (see serving-contract) |
+| Git repo connection | disconnected | dashboard |
+| Primary domain + www redirect | apex primary; www→apex | dashboard Domain settings |
+
+## CI secrets (GitHub Actions)
+
+| Secret | Purpose |
+|--------|---------|
+| `VERCEL_TOKEN` | Auth for the Vercel CLI |
+| `VERCEL_ORG_ID` | Target org (from `.vercel/project.json`) |
+| `VERCEL_PROJECT_ID` | Target project (from `.vercel/project.json`) |

--- a/specs/001-vercel-cd-migration/plan.md
+++ b/specs/001-vercel-cd-migration/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Migrate hosting & CD to Vercel
+
+**Branch**: `001-vercel-cd-migration` | **Date**: 2026-07-01 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/001-vercel-cd-migration/spec.md`
+
+## Summary
+
+Move hosting and CD off the manual GCP VM (nginx + certbot) to Vercel. The decisive constraint is
+that the site's PDF is rendered at build time by headless Chromium, which does **not** run reliably
+in Vercel's native build image. The plan therefore **builds the whole site (HTML + PDF) in GitHub
+Actions using the repo's pinned Playwright Chromium — the environment that already works — and
+deploys the prebuilt `dist/` to Vercel via the Vercel CLI** (`vercel build` / `vercel deploy
+--prebuilt`), with Vercel's own git build disabled. This guarantees the PDF is rendered by the same
+Chromium everywhere (reproducibility + parity), makes Vercel a pure static host/CDN/TLS/domain
+provider, and folds in issue #24 (vendor fonts/CSS) so the CI build is deterministic offline.
+
+## Technical Context
+
+**Language/Version**: Node.js 22 (existing).
+
+**Primary Dependencies**: Handlebars (templating), Playwright (headless Chromium for PDF),
+`fs-extra`, `dayjs`, `speakingurl`. New: Vercel CLI (`vercel`, used in CI only). No new runtime deps
+in the app (explicitly **not** adding `@sparticuz/chromium`).
+
+**Storage**: N/A — static site; output is `dist/` (HTML + assets + PDF).
+
+**Testing**: No unit tests (per constitution). Verification = `make lint` (Super-Linter, the CI
+gate) + visual check of the generated HTML/PDF + the deploy quickstart.
+
+**Target Platform**: Vercel (static hosting + CDN + automatic TLS + custom domains + preview
+deployments). Build runs on GitHub Actions `ubuntu-latest`.
+
+**Project Type**: Single project — static-site generator (see `AGENTS.md`).
+
+**Performance Goals**: N/A beyond "loads fast" — edge-cached static assets. Build time target:
+keep CI build+deploy under ~3 min (cache the Playwright browser).
+
+**Constraints**:
+- PDF must be byte-faithful to the local build → render with the lockfile-pinned Playwright
+  Chromium, never a substitute binary.
+- Build must succeed with **no external CDN access** (issue #24): vendor Roboto, Bootstrap 5.2.0,
+  and Font Awesome 6.1.2 into `src/assets/` and reference them locally; drop reliance on
+  `networkidle`; add an explicit `page.goto` timeout so a missing asset fails fast.
+- DNS changes are owner-run at the registrar (outside the repo).
+- Canonical host `valerio.dev` (apex); `www` 301-redirects to it.
+
+**Scale/Scope**: One static page + one PDF; single maintainer; low traffic.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Makefile is the interface | **Pass (with action)** — the CI workflow invokes `make page` to build; a thin `make deploy` (wrapping `vercel deploy --prebuilt`) is added so the deploy command lives in the Makefile too. The retired VM targets are removed. No ad-hoc commands introduced. |
+| II. Self-review before done | **Pass** — each implementation PR (>10 lines) runs `/code-review` + records the gate. |
+| III. Docs stay in sync | **Pass (with action)** — `docs/ci-cd.md`, `docs/architecture.md`, `README.md`, `AGENTS.md` updated in the same PRs; an ADR records the "build in CI, deploy prebuilt to Vercel" decision. |
+| IV. Validate locally; CI is the gate | **Pass** — `make page` validates the build locally (incl. offline); Super-Linter stays the lint gate; the deploy workflow is additive. |
+| V. Reproducible and minimal | **Pass** — Strategy B keeps one pinned Chromium; no new runtime deps; vendored fonts remove network nondeterminism. |
+
+No violations → Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-vercel-cd-migration/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions & rationale
+├── data-model.md        # Phase 1 — config/deploy entities
+├── quickstart.md        # Phase 1 — end-to-end validation guide
+├── contracts/
+│   ├── serving-contract.md   # HTTP surface: routes, redirects, headers, TLS
+│   └── deploy-contract.md    # CI → Vercel deploy interface
+└── tasks.md             # Phase 2 — created by /speckit-tasks (not here)
+```
+
+### Source Code (repository root)
+
+```text
+vercel.json                      # NEW — outputDirectory=dist, git.deploymentEnabled=false,
+                                 #       cleanUrls, cache-control + security headers
+.github/workflows/
+├── superlinter.yml              # unchanged — lint gate
+└── deploy.yml                   # NEW — build (Node 22 + pinned Playwright) → vercel deploy --prebuilt
+src/
+├── build.js                     # EDIT — await buildPdf(); fail on PDF error
+├── utils/pdf.js                 # EDIT — explicit timeout; drop networkidle reliance
+├── templates/index.html         # EDIT — reference vendored fonts/CSS instead of CDNs (#24)
+└── assets/
+    └── vendor/                  # NEW — vendored Roboto, Bootstrap 5.2.0, Font Awesome 6.1.2 (#24)
+Makefile                         # EDIT — remove VM/nginx/certbot targets; add `make deploy`
+docker-compose.yml               # REMOVE (final phase) — app-builder/nginx/certbot services
+config/nginx/                    # REMOVE (final phase)
+Dockerfile                       # KEEP — repurposed as the standalone build image for `make dev-build` (FR-011)
+package.json                     # EDIT — drop the dead `predeploy` (gh-pages) script
+docs/{ci-cd,architecture}.md, README.md, AGENTS.md   # EDIT — new deploy model; remove stale gh-pages docs
+docs/adr/000X-*.md               # NEW — ADR for the CI-build + prebuilt-deploy decision
+```
+
+**Structure Decision**: Single project, unchanged layout. Changes are additive config
+(`vercel.json`, `deploy.yml`), a small source refactor (vendored assets + PDF await/timeout), and —
+as the final phase — removal of the VM deploy stack.
+
+## Phases (mapping to spec user stories)
+
+- **Phase A — reproducible build + vercel config (US1 / P1)**: vendor fonts (#24), fix
+  `pdf.js`/`build.js` (await + timeout), add `vercel.json`, add the `deploy.yml` workflow,
+  configure Vercel project (disable git build, set secrets). Outcome: green preview deploys per PR
+  and production deploys from `main`.
+- **Phase B — domain cutover (US2 / P2)**: add `valerio.dev` + `www` to the Vercel project, set
+  `www` → 301 → apex, owner updates DNS (A + CNAME), verify serving + TLS. Restores the live site.
+- **Phase C — retire the VM stack (US3 / P3)**: remove `docker-compose.yml` (app-builder + nginx +
+  certbot), `config/nginx/`, and the retired Makefile deploy targets (`webserver*`, `certificates*`,
+  `logs-*`, `remove-*`, `build`, `down`, `all`). **Keep** the `Dockerfile` + `make dev-build` (the
+  no-local-node build path — decouple it from the removed docker-compose so FR-011 holds). Rewrite
+  the deploy docs (`docs/ci-cd.md`, `docs/architecture.md`, `README.md`, `AGENTS.md`) to the
+  push-to-Vercel model, **including removing the stale GitHub Pages / `npm run deploy` instructions
+  in `README.md` and the now-dead `predeploy` script in `package.json`**. (VM already powered down —
+  no separate decommission.)
+
+## Complexity Tracking
+
+No constitution violations — no entries.

--- a/specs/001-vercel-cd-migration/quickstart.md
+++ b/specs/001-vercel-cd-migration/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: validate the Vercel migration
+
+End-to-end validation scenarios that prove the feature works. Each maps to spec user stories and
+success criteria. Run in order; later phases depend on earlier ones. (Implementation details live in
+`tasks.md`; this is a run/verify guide.)
+
+## Prerequisites
+
+- Node 22 + repo deps (`npm ci`) and the pinned Playwright Chromium
+  (`npx playwright install --with-deps chromium`), or the Dev Container.
+- A Vercel account with the `cv` project; `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` set
+  as GitHub Actions secrets.
+- Owner access to the `valerio.dev` DNS (for Phase B only).
+
+## Scenario 1 — Reproducible, self-contained build (US1 / SC-003, FR-003)
+
+```sh
+make page                      # builds dist/ incl. the PDF
+```
+
+Expected: `dist/index.html` + `dist/<slug>.pdf` produced; open both and confirm correct fonts
+(Roboto) and Font Awesome icons render. Then prove no CDN dependency — build with external network
+blocked (e.g. disable networking / offline) and confirm the build still succeeds and the PDF fonts
+are unchanged (no fallback fonts, no hang). `grep -r "https://" dist/index.html` returns **no**
+font/CSS CDN links.
+
+## Scenario 2 — Preview deployment per PR (US1 / FR-002, SC-002)
+
+Open a PR. Expected: the `deploy` workflow builds and posts a **preview URL** comment on the PR.
+Open the URL → the CV page and the PDF render correctly over HTTPS. A build failure fails the job
+and posts no preview (FR-008).
+
+## Scenario 3 — Production deployment from main (US1 / FR-001, SC-001, SC-006)
+
+Merge to `main`. Expected: the workflow runs `--prod`; the deployment is aliased to the production
+domain. No manual server or certificate step is involved (SC-006). Verify the serving contract:
+
+```sh
+curl -sI https://<production-deployment-url>/            # 200, text/html; client Cache-Control: public, max-age=0
+curl -sI https://<production-deployment-url>/<slug>.pdf  # 200, application/pdf
+# note: s-maxage / stale-while-revalidate are edge-only and stripped from the client response
+```
+
+## Scenario 4 — Domain cutover (US2 / FR-006, FR-007, FR-009, SC-004, SC-005)
+
+Owner steps (runbook): add `valerio.dev` + `www.valerio.dev` to the Vercel project; set `www` to
+**Redirect to** the apex; lower DNS TTL; **verify Vercel serving + a valid certificate first**, then
+point DNS (`A → 76.76.21.21`, `www CNAME → <project>.vercel-dns-###.com`). Verify:
+
+```sh
+dig A valerio.dev +short                       # matches the A record shown in Vercel Domain settings
+curl -sI https://valerio.dev/                  # 200, valid TLS
+curl -sI https://www.valerio.dev/              # 301 → https://valerio.dev/
+```
+
+Because the site is currently down and the VM is already off, this **restores** availability — there
+is no rollback target and no downtime to protect (per Clarifications).
+
+## Scenario 5 — VM stack retired (US3 / FR-010)
+
+After production is verified on Vercel:
+
+```sh
+grep -rn "webserver\|certbot\|nginx" Makefile   # no deploy targets remain
+ls docker-compose.yml config/nginx 2>/dev/null  # removed
+```
+
+Expected: the manual deploy stack + its Makefile targets are gone; `docs/ci-cd.md` / `README` /
+`AGENTS.md` describe the push-to-deploy model with no manual server/cert instructions.
+
+## Success check
+
+All five scenarios pass → SC-001…SC-007 satisfied and the migration is complete.

--- a/specs/001-vercel-cd-migration/research.md
+++ b/specs/001-vercel-cd-migration/research.md
@@ -1,0 +1,131 @@
+# Phase 0 Research: Migrate hosting & CD to Vercel
+
+Resolves the open technical questions the spec deferred to planning. Grounded in current
+(2025–2026) Vercel + Playwright documentation.
+
+## 1. How is the PDF produced in a Vercel world? (the central fork)
+
+**Decision**: Build the **whole site (HTML + PDF) in GitHub Actions** using the repo's
+lockfile-pinned Playwright Chromium, then deploy the prebuilt `dist/` to Vercel via the Vercel CLI
+(`vercel build` → `vercel deploy --prebuilt`). Vercel never launches a browser.
+
+**Rationale**:
+- Playwright's bundled Chromium does **not** launch reliably in Vercel's native build image
+  (Amazon Linux); the canonical failure is missing shared libraries (`libnspr4.so`, etc.), and you
+  cannot install system deps there the way `playwright install-deps` expects on Debian. This is
+  almost certainly why the current (no-`vercel.json`) Vercel builds fail — Vercel auto-detects and
+  runs `node src/build.js`, which calls `chromium.launch()`.
+- GitHub Actions `ubuntu-latest` is the same Debian/Ubuntu family the repo's `node:22-bookworm`
+  Docker/devcontainer already use, where `playwright install --with-deps chromium` works. Rendering
+  the PDF there uses the **exact pinned Chromium** — so the PDF is byte-faithful to local builds
+  (satisfies SC-007 parity and FR-003/Principle V reproducibility) with **zero** env-specific launch
+  branching and **no** new runtime dependency.
+- A static CV's PDF is a build artifact, not per-request compute — there's no reason to put Chromium
+  in Vercel's build or runtime.
+
+**Alternatives considered**:
+- **Native Vercel build via `@sparticuz/chromium` + `playwright-core`** — rejected: introduces a
+  *second* Chromium binary (decoupled from the lockfile), env-specific launch code, and a package
+  designed for the AWS Lambda *runtime*, not a build step. Breaks parity + reproducibility; more
+  moving parts. Fails every stated priority.
+- **Runtime PDF via a Vercel Serverless Function** — rejected: over-engineered; turns a build
+  artifact into per-request compute with cold-start/size-limit concerns, still non-pinned Chromium.
+- **Fixing system libs for stock Playwright in Vercel's build** — rejected: cannot reliably install
+  the missing `.so` deps in Vercel's build image; a losing battle.
+
+## 2. Disabling Vercel's own build; deploying prebuilt from CI
+
+**Decision**: Commit `"git": { "deploymentEnabled": false }` in `vercel.json` **and** keep the
+Vercel project's GitHub repo disconnected (belt-and-suspenders). Deploy only via
+`vercel deploy --prebuilt` from GitHub Actions.
+
+**Rationale**: `git.deploymentEnabled: false` is the first-class, repo-committed switch that turns
+off Vercel's automatic git builds for all branches (the deprecated `github.enabled` is superseded);
+CLI deploys are unaffected because they hit the project directly via token, not the git webhook.
+A project with no connected repo simply has nothing to auto-build, which most robustly kills the
+current failing builds. `vercel deploy --prebuilt` uploads the previously generated `.vercel/output`
+and **skips the build on Vercel**.
+
+**Alternatives**: "Ignored Build Step" (`git.ignoreCommand`)/dashboard toggles — still fire the git
+integration and create skipped-deployment noise; the right tool for conditional monorepo skips, not
+for "never build on Vercel." Dashboard-only toggles aren't versioned.
+
+**CI flow** (`.github/workflows/deploy.yml`): checkout → setup Node 22 → `npm ci` →
+`npx playwright install --with-deps chromium` (cache `~/.cache/ms-playwright` keyed on the resolved
+Playwright version **and** runner OS — note `--with-deps` reinstalls apt system libraries each run,
+so the deps step is not fully cached) → `make page` (build incl. PDF) → `npm i -g vercel` →
+`make deploy` (wraps `vercel pull` → `vercel build` → `vercel deploy --prebuilt`, `--prod` selected
+via a flag). `--prod` on push to `main` (aliases to `valerio.dev`); plain deploy on PRs (preview
+URL). Secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
+
+**Critical config**: `vercel.json` sets `framework: null` + `buildCommand: ""` so `vercel build`
+**packages the already-built `dist/`** instead of auto-detecting the `build` npm script and
+re-running `node src/build.js` (which would launch Chromium a second time). Without this override
+the "Vercel never launches a browser" property does not hold.
+
+## 3. `vercel.json` for a prebuilt static site + caching
+
+**Decision**: `outputDirectory: "dist"`, `cleanUrls: true`, `trailingSlash: false`, and explicit
+per-type `Cache-Control`, plus baseline security headers.
+
+**Rationale**: Vercel's default (`max-age=0, must-revalidate`) caches nothing. `s-maxage` and
+`stale-while-revalidate` control Vercel's edge only and are **stripped before the response reaches
+the client** (so `curl -sI` shows `public, max-age=0, must-revalidate` — verify the client value,
+not the edge directives), while `max-age` controls the browser, and a new deployment invalidates the
+edge cache — so `max-age=0, s-maxage=…, stale-while-revalidate=…` gives "browser always gets the
+freshest HTML/PDF after a deploy, edge still serves fast, **no stale-cache lock-in**" (satisfies
+FR-012). The repo's assets have **stable, unhashed filenames**, so
+`immutable` would strand old CSS after a redesign → assets use `max-age=0, s-maxage=31536000,
+stale-while-revalidate` (switch to `max-age=31536000, immutable` only if content-hashing is added).
+
+**Concrete config** captured in [`contracts/serving-contract.md`](contracts/serving-contract.md).
+
+## 4. Apex vs www + DNS
+
+**Decision**: `valerio.dev` (apex) canonical; `www.valerio.dev` → **301** → apex. Do the redirect
+via Vercel **Domain settings** (add both domains, mark apex primary, set www "Redirect to" apex),
+**not** a `vercel.json` `redirects` rule.
+
+**Rationale**: `vercel.json` `redirects` match by path, not host, so they're the wrong tool for
+apex↔www; the domain-level redirect is a proper host-wide 301 at the edge. DNS records (owner-run at
+the registrar, using the **exact values shown in the project's Domain settings**): apex `A → <IP
+from dashboard>` (`76.76.21.21` is the legacy default and still valid, but read the dashboard value);
+`www` `CNAME → <project>.vercel-dns-###.com`. Vercel auto-provisions Let's Encrypt TLS once DNS
+verifies.
+
+**Caveat**: Vercel's own recommendation is the *opposite* (www primary via CNAME) because a CNAME
+lets their CDN steer traffic; apex-primary hard-codes an Anycast IP. Apex-primary is fully
+supported and chosen for the cleaner canonical URL — an accepted, minor tradeoff for a personal CV.
+
+## 5. Preview/production visibility on PRs
+
+**Decision**: Capture the deploy URL from the Vercel CLI `stdout` and post it to the PR ourselves
+(`actions/github-script` or `gh pr comment`) / job summary.
+
+**Rationale**: Disabling the Vercel git integration means the **Vercel bot no longer auto-comments**
+preview URLs or sets commit statuses. The CLI always prints the deployment URL to stdout, so the
+workflow surfaces it. Prefer the minimal `github-script`/`gh` comment over a third-party action
+(Principle V: minimal trust surface), unless the GitHub "Deployments" tab integration is wanted.
+
+## 6. Issue #24 — self-contained build (prerequisite for P1)
+
+**Decision**: Vendor the three CDN dependencies into `src/assets/vendor/` and reference them
+locally; render with `waitUntil: 'load'` and `await page.evaluate(() => document.fonts.ready)` before
+`page.pdf()` so the vendored fonts are actually applied; add an explicit `page.goto` timeout as
+defense-in-depth; and fix `build.js` so the PDF is awaited and failures are fatal — wrap the build
+body in a CommonJS-safe `(async () => { … })().catch(err => { console.error(err); process.exit(1) })`
+(a bare top-level `await` is a SyntaxError in this CommonJS module).
+
+Note: once assets are local (`file://`), `networkidle` resolves immediately, so it is no longer a
+hang risk — but a `goto` timeout alone does **not** catch a *missing* local font (the page still
+"loads" with fallback fonts). `document.fonts.ready` + the quickstart's visual check are what
+guarantee font correctness (SC-003/FR-004).
+
+**Rationale**: The template loads Roboto (Google Fonts), Bootstrap 5.2.0 (jsDelivr), and Font
+Awesome 6.1.2 (cdnjs) from CDNs, and `pdf.js` waits on `networkidle` — so a slow/unreachable CDN can
+hang the build or silently produce a fallback-font PDF. Vendoring makes the CI-rendered PDF
+deterministic regardless of network (FR-003, SC-003) and is a hard prerequisite for reliable Vercel
+builds. Font Awesome and Roboto ship self-host bundles; Bootstrap CSS is a single vendored file.
+
+**Alternatives**: keep CDNs + rely on CI network — rejected (nondeterministic, the exact #24
+problem). Replace the browser-based PDF with a non-Chromium renderer — rejected (parity risk).

--- a/specs/001-vercel-cd-migration/spec.md
+++ b/specs/001-vercel-cd-migration/spec.md
@@ -1,0 +1,204 @@
+# Feature Specification: Migrate hosting & CD to Vercel
+
+**Feature Branch**: `001-vercel-cd-migration`
+
+**Created**: 2026-07-01
+
+**Status**: Draft
+
+**Input**: User description: "Migrate hosting and continuous deployment from the manual GCP VM to
+Vercel. The site is a static build (`npm run build` → `dist/` with HTML, assets, and a PDF). Vercel
+is already linked to the repo and auto-deploys on push/PR, but every deployment currently fails and
+there is no `vercel.json`; real traffic still hits the GCP VM (nginx + manual certbot), where DNS
+points. Goals: builds succeed and serve HTML + PDF on every push (production from main, preview per
+PR); automatic TLS; retire the manual VM/nginx/certbot stack and its Makefile targets; repoint DNS
+for valerio.dev + www to the new platform with a safe, reversible cutover; preserve local dev.
+Constraint: builds must be reproducible/self-contained (no reliance on remote CDN fonts at build
+time — issue #24). Parity: HTML + a correctly-rendered PDF must remain. Non-goals: changing CV
+content, redesigning the page, or switching the templating/build tooling beyond what deployment
+requires."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The site builds and serves automatically from the platform (Priority: P1)
+
+The site owner pushes a change; the hosting platform builds the project and serves the resulting
+HTML page **and** downloadable PDF at a working URL, with no manual server, build, or certificate
+steps. The same mechanism produces an isolated preview for every pull request.
+
+**Why this priority**: This is the foundation of the whole migration. Until a platform build
+*succeeds* and serves both artifacts, nothing else (custom domain, VM retirement) can proceed.
+Today every deployment fails, so this is the first and most critical slice.
+
+**Independent Test**: Trigger a deployment (push to a branch / open a PR), open the resulting
+platform URL, confirm the CV page renders with correct fonts/layout and the PDF is downloadable and
+correctly rendered — all without touching a server or issuing a certificate manually.
+
+**Acceptance Scenarios**:
+
+1. **Given** a commit pushed to the default branch, **When** the platform runs its build, **Then**
+   the build succeeds and the production URL serves the current HTML page and the PDF.
+2. **Given** an open pull request, **When** the platform builds the PR, **Then** a preview URL
+   serves the page and PDF, and the deployment status is reported back on the PR.
+3. **Given** a build environment with **no access to external font/CSS CDNs**, **When** the build
+   runs, **Then** it still succeeds and the PDF is rendered with the correct fonts (no fallback
+   fonts, no hang).
+4. **Given** a build that fails, **When** the platform processes it, **Then** the previously
+   serving production deployment stays live (a broken build is never promoted).
+
+---
+
+### User Story 2 - Visitors reach the real domain on the new platform over HTTPS (Priority: P2)
+
+A visitor navigates to `valerio.dev` (or `www.valerio.dev`) and is served the CV from the new
+platform over a valid, automatically-managed HTTPS certificate. The cutover from the old VM is done
+via DNS in a way that is verifiable and reversible.
+
+**Why this priority**: This is where real users benefit — production traffic actually moves to the
+new platform. It depends on P1 (a working deployment must exist first) and on a DNS change the owner
+performs manually.
+
+**Independent Test**: After the cutover runbook is executed, confirm `valerio.dev` and
+`www.valerio.dev` resolve to the new platform, load the CV over HTTPS with a valid certificate, and
+that a documented rollback restores the VM if needed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the domain has been added to the platform and DNS updated, **When** a visitor loads
+   `valerio.dev`, **Then** the CV is served from the new platform over HTTPS with a valid,
+   auto-renewing certificate.
+2. **Given** the canonical host chosen in FR-007, **When** a visitor loads the other host, **Then**
+   they are permanently redirected to the canonical host.
+3. **Given** the cutover is in progress, **When** a problem is detected, **Then** the runbook's
+   rollback restores serving from the VM (DNS reverted) with no data loss.
+
+---
+
+### User Story 3 - The manual VM/nginx/certbot deploy stack is retired (Priority: P3)
+
+Once the new platform is authoritative and verified in production, the manual deploy machinery
+(docker-compose nginx + certbot services, nginx config, and the deploy-oriented Makefile targets) is
+removed from the repository and the docs are updated to describe the new push-to-deploy model. The
+VM is decommissioned.
+
+**Why this priority**: Pure cleanup/cost-reduction that is only safe *after* P1 and P2 are verified.
+It delivers value (no dead code, no VM cost, no confusion) but must come last.
+
+**Independent Test**: Inspect the repo — the manual deploy stack and its Makefile targets are gone,
+`docs/ci-cd.md`/`README`/`AGENTS.md` describe the new model, and the VM is powered down with the
+site still fully served by the platform.
+
+**Acceptance Scenarios**:
+
+1. **Given** production is verified on the new platform, **When** the retirement change lands,
+   **Then** the manual deploy stack and its Makefile targets are removed and the deploy docs reflect
+   the platform-based model.
+2. **Given** the stack is retired, **When** a contributor looks for how to deploy, **Then** the docs
+   point them to the automatic platform deploy (no manual server/cert instructions remain).
+
+---
+
+### Edge Cases
+
+- **Build depends on a third-party CDN that is slow/unreachable at build time** → the build must not
+  hang or silently produce a fallback-font PDF; dependencies are self-contained so the outcome is
+  deterministic. (Issue #24.)
+- **PDF rendering fails in the platform build environment** → the deployment fails loudly (build
+  error) rather than promoting a deployment missing or misrendering the PDF.
+- **DNS propagation is partial/slow during cutover** → visitors on either resolver path still reach
+  a working site; the VM remains live as rollback until propagation is verified.
+- **Certificate not yet provisioned right after adding the domain** → cutover waits for a valid
+  certificate before DNS is switched (verify-before-switch).
+- **A contributor runs a now-removed `make webserver-*` / `make certificates` target** → the target
+  no longer exists and docs point to the new model (no partial/old deploy path is silently invoked).
+- **`www` vs apex** → both hostnames resolve and serve; the non-canonical one redirects.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every push to the default branch MUST automatically build and deploy the site to
+  production, serving both the HTML page and the PDF, with no manual server, build, or certificate
+  steps.
+- **FR-002**: Every pull request MUST produce an isolated preview deployment reachable via URL, and
+  the deployment's success/failure status MUST be reported on the pull request.
+- **FR-003**: The deployment build MUST be reproducible and self-contained — it MUST NOT depend on
+  the availability of third-party CDNs (fonts/CSS) at build time. (Addresses issue #24.)
+- **FR-004**: The deployed site MUST include both the HTML page and a correctly-rendered,
+  consistently-fonted PDF, at parity with the pre-migration output.
+- **FR-005**: The PDF MUST remain available at its existing download URL — same path **and**
+  filename — so external links do not break.
+- **FR-006**: HTTPS certificates for the production domain MUST be provisioned and renewed
+  automatically by the platform, with no manual certificate issuance or renewal.
+- **FR-007**: After cutover, `valerio.dev` and `www.valerio.dev` MUST serve the site from the new
+  platform. The canonical host and redirect direction is [NEEDS CLARIFICATION: canonical domain not
+  decided — apex `valerio.dev` with `www` redirecting to it, or the reverse?].
+- **FR-008**: A failed build MUST NOT replace the currently-serving production deployment (last good
+  deployment stays live).
+- **FR-009**: The DNS cutover MUST follow a documented runbook that (a) lowers record TTL
+  beforehand, (b) verifies platform serving and a valid certificate before switching, and (c)
+  preserves a rollback to the VM until the new platform is verified. DNS record changes are executed
+  manually by the site owner at the DNS provider and are outside the repository.
+- **FR-010**: The manual VM/nginx/certbot deploy stack and its deploy-oriented Makefile targets MUST
+  be removed once the platform is authoritative, and the deploy documentation updated accordingly.
+  The timing/scope is [NEEDS CLARIFICATION: is stack retirement + VM decommission part of THIS
+  initiative (as its final phase, after cutover is verified) or a separate follow-up?].
+- **FR-011**: Local development (build, live preview, and lint) MUST remain functional and
+  unchanged by the migration.
+- **FR-012**: The cutover MUST retain a working rollback to the VM for
+  [NEEDS CLARIFICATION: rollback retention window not specified — how long should the VM stay live
+  and DNS-reversible after cutover before it is decommissioned?].
+- **FR-013**: Content caching MUST NOT prevent a new successful deployment from becoming visible
+  promptly, nor prevent a DNS rollback from restoring the previous source within the cutover
+  verification window (no stale-cache lock-in during cutover).
+
+### Key Entities
+
+- **Deployment environments**: *Production* (served from the default branch) and *Preview* (one per
+  pull request) — each a fully built, independently reachable instance of the site.
+- **Served artifacts**: the HTML CV page and the downloadable PDF; both must be present and at
+  parity for a deployment to be considered valid.
+- **Production domain**: `valerio.dev` and `www.valerio.dev`, with one canonical host and the other
+  redirecting; TLS is platform-managed.
+- **Cutover runbook**: the owner-executed sequence (lower TTL → add domain on platform → verify
+  serving + certificate → switch DNS → verify → keep VM as rollback → decommission).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of pushes to the default branch result in an automatically deployed, publicly
+  reachable production site (HTML + PDF) with zero manual server or certificate steps.
+- **SC-002**: Every pull request receives a working preview URL (page + PDF render correctly) with
+  its deployment status shown on the PR.
+- **SC-003**: The build succeeds and produces a correctly-fonted PDF with **no** access to external
+  font/CSS CDNs at build time (verified by building with external CDN access blocked).
+- **SC-004**: The production domain (`valerio.dev` and `www.valerio.dev`) loads over HTTPS with a
+  valid, automatically-renewing certificate, requiring **zero** manual certificate renewals.
+- **SC-005**: The DNS cutover completes with continuous availability — external uptime probes record
+  zero failed requests across the cutover window — and a rehearsed rollback can restore VM serving.
+- **SC-006**: Shipping a content change requires **zero** manual deploy steps after migration
+  (versus the current multi-step manual VM + certbot process).
+- **SC-007**: The migrated HTML page and PDF match a baseline captured immediately before cutover
+  (same fonts, layout, and content, confirmed by side-by-side comparison) — no visual or content
+  regression.
+
+## Assumptions
+
+- The target platform is **Vercel**, already linked to the GitHub repo (project
+  `bruno-valerios-projects/cv`); this initiative makes its builds succeed and cuts traffic over to
+  it, rather than introducing a new integration from scratch.
+- Issue **#24** (vendoring fonts/CSS so the build is self-contained) is **in scope** and is a
+  prerequisite for User Story 1 (P1): reliable platform builds depend on it.
+- Production deploys from the default branch (`main`) and previews from pull requests, matching the
+  platform's standard git-driven model.
+- **DNS changes are performed manually by the site owner** at their DNS provider; the repository and
+  automated tooling cannot modify DNS. Record TTL is lowered ahead of the cutover.
+- Near-zero downtime is expected; the cutover is DNS-based with the VM kept live as a rollback until
+  the platform is verified in production.
+- Any historical GitHub Pages deployment is considered superseded and out of active use; it is not
+  part of the retirement scope unless found to still serve traffic.
+- Feature parity is required: the HTML page and a correctly-rendered PDF remain available, with the
+  PDF at its current path.
+- The *how* of producing the PDF within the platform build (e.g., headless-browser rendering in the
+  build vs. an alternative) is an implementation decision deferred to `/speckit-plan`, not this spec.

--- a/specs/001-vercel-cd-migration/spec.md
+++ b/specs/001-vercel-cd-migration/spec.md
@@ -18,6 +18,20 @@ time — issue #24). Parity: HTML + a correctly-rendered PDF must remain. Non-go
 content, redesigning the page, or switching the templating/build tooling beyond what deployment
 requires."
 
+## Clarifications
+
+### Session 2026-07-01
+
+- Q: Canonical host for the production domain (the other redirects)? → A: `valerio.dev` (apex) is
+  canonical; `www.valerio.dev` issues a permanent (301) redirect to it.
+- Q: Is retiring the manual VM/nginx/certbot stack + decommissioning the VM part of this initiative?
+  → A: Yes — as the final phase, after the Vercel cutover is verified. (The VM is already powered
+  down, so the remaining work is removing the repo deploy stack + Makefile targets and updating
+  docs.)
+- Q: How long should the VM stay live as a rollback after cutover? → A: No rollback needed — the
+  site is **not currently live** and the VM is **already down**, so there is no rollback target and
+  no downtime to protect. The cutover only *restores* service.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - The site builds and serves automatically from the platform (Priority: P1)
@@ -51,26 +65,28 @@ correctly rendered — all without touching a server or issuing a certificate ma
 ### User Story 2 - Visitors reach the real domain on the new platform over HTTPS (Priority: P2)
 
 A visitor navigates to `valerio.dev` (or `www.valerio.dev`) and is served the CV from the new
-platform over a valid, automatically-managed HTTPS certificate. The cutover from the old VM is done
-via DNS in a way that is verifiable and reversible.
+platform over a valid, automatically-managed HTTPS certificate. Because the site is currently down
+(the VM is already decommissioned), this **restores** availability on the domain; the cutover is a
+verify-before-switch DNS change with no live site to regress.
 
-**Why this priority**: This is where real users benefit — production traffic actually moves to the
-new platform. It depends on P1 (a working deployment must exist first) and on a DNS change the owner
-performs manually.
+**Why this priority**: This is where real users benefit — it brings the currently-down site back
+online on `valerio.dev`. It depends on P1 (a working deployment must exist first) and on a DNS
+change the owner performs manually.
 
 **Independent Test**: After the cutover runbook is executed, confirm `valerio.dev` and
-`www.valerio.dev` resolve to the new platform, load the CV over HTTPS with a valid certificate, and
-that a documented rollback restores the VM if needed.
+`www.valerio.dev` resolve to the new platform and load the CV over HTTPS with a valid certificate,
+with `www` redirecting to the apex.
 
 **Acceptance Scenarios**:
 
 1. **Given** the domain has been added to the platform and DNS updated, **When** a visitor loads
    `valerio.dev`, **Then** the CV is served from the new platform over HTTPS with a valid,
    auto-renewing certificate.
-2. **Given** the canonical host chosen in FR-007, **When** a visitor loads the other host, **Then**
-   they are permanently redirected to the canonical host.
-3. **Given** the cutover is in progress, **When** a problem is detected, **Then** the runbook's
-   rollback restores serving from the VM (DNS reverted) with no data loss.
+2. **Given** `valerio.dev` (apex) is canonical, **When** a visitor loads `www.valerio.dev`, **Then**
+   they are permanently (301) redirected to `valerio.dev`.
+3. **Given** the domain is added but serving/certificate is not yet confirmed, **When** the owner
+   runs the cutover runbook, **Then** DNS is not switched until platform serving and a valid
+   certificate are verified (verify-before-switch).
 
 ---
 
@@ -79,7 +95,8 @@ that a documented rollback restores the VM if needed.
 Once the new platform is authoritative and verified in production, the manual deploy machinery
 (docker-compose nginx + certbot services, nginx config, and the deploy-oriented Makefile targets) is
 removed from the repository and the docs are updated to describe the new push-to-deploy model. The
-VM is decommissioned.
+VM is already powered down, so this phase is chiefly repo cleanup (removing the dead deploy stack)
+plus doc updates.
 
 **Why this priority**: Pure cleanup/cost-reduction that is only safe *after* P1 and P2 are verified.
 It delivers value (no dead code, no VM cost, no confusion) but must come last.
@@ -105,8 +122,9 @@ site still fully served by the platform.
   deterministic. (Issue #24.)
 - **PDF rendering fails in the platform build environment** → the deployment fails loudly (build
   error) rather than promoting a deployment missing or misrendering the PDF.
-- **DNS propagation is partial/slow during cutover** → visitors on either resolver path still reach
-  a working site; the VM remains live as rollback until propagation is verified.
+- **DNS propagation is partial/slow during cutover** → until propagation completes, some resolvers
+  may still return the old (now-dead) VM IP; because the site is already down this is not a
+  regression, and full propagation restores service everywhere.
 - **Certificate not yet provisioned right after adding the domain** → cutover waits for a valid
   certificate before DNS is switched (verify-before-switch).
 - **A contributor runs a now-removed `make webserver-*` / `make certificates` target** → the target
@@ -131,26 +149,23 @@ site still fully served by the platform.
 - **FR-006**: HTTPS certificates for the production domain MUST be provisioned and renewed
   automatically by the platform, with no manual certificate issuance or renewal.
 - **FR-007**: After cutover, `valerio.dev` and `www.valerio.dev` MUST serve the site from the new
-  platform. The canonical host and redirect direction is [NEEDS CLARIFICATION: canonical domain not
-  decided — apex `valerio.dev` with `www` redirecting to it, or the reverse?].
+  platform, with `valerio.dev` (apex) as the canonical host and `www.valerio.dev` issuing a
+  permanent (301) redirect to it.
 - **FR-008**: A failed build MUST NOT replace the currently-serving production deployment (last good
   deployment stays live).
 - **FR-009**: The DNS cutover MUST follow a documented runbook that (a) lowers record TTL
-  beforehand, (b) verifies platform serving and a valid certificate before switching, and (c)
-  preserves a rollback to the VM until the new platform is verified. DNS record changes are executed
-  manually by the site owner at the DNS provider and are outside the repository.
-- **FR-010**: The manual VM/nginx/certbot deploy stack and its deploy-oriented Makefile targets MUST
-  be removed once the platform is authoritative, and the deploy documentation updated accordingly.
-  The timing/scope is [NEEDS CLARIFICATION: is stack retirement + VM decommission part of THIS
-  initiative (as its final phase, after cutover is verified) or a separate follow-up?].
+  beforehand, (b) verifies platform serving and a valid certificate **before** switching DNS, and
+  (c) repoints DNS to the platform and re-verifies. DNS record changes are executed manually by the
+  site owner at the DNS provider and are outside the repository. No rollback-to-VM step exists — the
+  VM is already down (see Assumptions).
+- **FR-010**: As the final phase of this initiative (after the cutover is verified), the manual
+  VM/nginx/certbot deploy stack and its deploy-oriented Makefile targets MUST be removed from the
+  repository and the deploy documentation updated accordingly. (The VM is already powered down, so
+  no separate decommission step remains.)
 - **FR-011**: Local development (build, live preview, and lint) MUST remain functional and
   unchanged by the migration.
-- **FR-012**: The cutover MUST retain a working rollback to the VM for
-  [NEEDS CLARIFICATION: rollback retention window not specified — how long should the VM stay live
-  and DNS-reversible after cutover before it is decommissioned?].
-- **FR-013**: Content caching MUST NOT prevent a new successful deployment from becoming visible
-  promptly, nor prevent a DNS rollback from restoring the previous source within the cutover
-  verification window (no stale-cache lock-in during cutover).
+- **FR-012**: Content caching MUST NOT prevent a new successful deployment from becoming visible
+  promptly — stale content must not linger after a deploy goes live.
 
 ### Key Entities
 
@@ -158,10 +173,10 @@ site still fully served by the platform.
   pull request) — each a fully built, independently reachable instance of the site.
 - **Served artifacts**: the HTML CV page and the downloadable PDF; both must be present and at
   parity for a deployment to be considered valid.
-- **Production domain**: `valerio.dev` and `www.valerio.dev`, with one canonical host and the other
-  redirecting; TLS is platform-managed.
+- **Production domain**: `valerio.dev` (canonical apex) and `www.valerio.dev` (permanent 301
+  redirect to the apex); TLS is platform-managed.
 - **Cutover runbook**: the owner-executed sequence (lower TTL → add domain on platform → verify
-  serving + certificate → switch DNS → verify → keep VM as rollback → decommission).
+  serving + certificate → switch DNS → verify). No rollback step — the VM is already down.
 
 ## Success Criteria *(mandatory)*
 
@@ -175,13 +190,14 @@ site still fully served by the platform.
   font/CSS CDNs at build time (verified by building with external CDN access blocked).
 - **SC-004**: The production domain (`valerio.dev` and `www.valerio.dev`) loads over HTTPS with a
   valid, automatically-renewing certificate, requiring **zero** manual certificate renewals.
-- **SC-005**: The DNS cutover completes with continuous availability — external uptime probes record
-  zero failed requests across the cutover window — and a rehearsed rollback can restore VM serving.
+- **SC-005**: After the DNS change, `valerio.dev` and `www.valerio.dev` resolve to and serve from
+  the platform within one TTL, restoring the currently-down site. (No downtime/rollback criterion
+  applies — there is no live site or VM to regress to.)
 - **SC-006**: Shipping a content change requires **zero** manual deploy steps after migration
   (versus the current multi-step manual VM + certbot process).
-- **SC-007**: The migrated HTML page and PDF match a baseline captured immediately before cutover
-  (same fonts, layout, and content, confirmed by side-by-side comparison) — no visual or content
-  regression.
+- **SC-007**: The deployed HTML page and PDF match a reference local build (`make page`) of the
+  same commit (same fonts, layout, and content, confirmed by side-by-side comparison) — no visual
+  or content regression.
 
 ## Assumptions
 
@@ -194,8 +210,9 @@ site still fully served by the platform.
   platform's standard git-driven model.
 - **DNS changes are performed manually by the site owner** at their DNS provider; the repository and
   automated tooling cannot modify DNS. Record TTL is lowered ahead of the cutover.
-- Near-zero downtime is expected; the cutover is DNS-based with the VM kept live as a rollback until
-  the platform is verified in production.
+- The site is **not currently live** and the GCP VM is **already powered down**; DNS still points
+  at the now-dead VM IP. The cutover therefore only *restores* availability — there is no live
+  production to protect and no rollback target, so downtime/rollback provisions are out of scope.
 - Any historical GitHub Pages deployment is considered superseded and out of active use; it is not
   part of the retirement scope unless found to still serve traffic.
 - Feature parity is required: the HTML page and a correctly-rendered PDF remain available, with the

--- a/specs/001-vercel-cd-migration/tasks.md
+++ b/specs/001-vercel-cd-migration/tasks.md
@@ -1,0 +1,207 @@
+---
+description: "Task list for Migrate hosting & CD to Vercel"
+---
+
+# Tasks: Migrate hosting & CD to Vercel
+
+**Input**: Design documents from `/specs/001-vercel-cd-migration/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: None. This repo has no test suite (constitution Principle IV); verification is `make lint`
+(Super-Linter, the CI gate) + the `quickstart.md` scenarios. No test tasks are generated.
+
+**Organization**: Grouped by user story (US1/P1 → US2/P2 → US3/P3). Unlike a typical multi-story
+feature, **these stories are sequential**: US2 (cutover) needs US1 (working deploy) live, and US3
+(retire the VM stack) is only safe after US2 is verified.
+
+**Owner-run tasks**: some steps happen in the Vercel dashboard / DNS registrar and **cannot be done
+from the repo** — they are marked **(owner-run)** with the location instead of a file path.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (setup, foundational, and polish tasks have no story label)
+
+---
+
+## Phase 1: Setup (credentials & Vercel project config)
+
+**Purpose**: one-time prerequisites so CLI deploys work and Vercel stops its own failing builds.
+
+- [ ] T001 **(owner-run — Vercel dashboard)** In the `cv` Vercel project, disconnect the GitHub Git
+      integration (Settings → Git) so no server-side auto-builds run; CLI `--prebuilt` deploys are
+      unaffected.
+- [ ] T002 **(owner-run — Vercel dashboard/CLI + GitHub)** Create a Vercel token; run `vercel link`
+      to obtain `VERCEL_ORG_ID` + `VERCEL_PROJECT_ID` (from `.vercel/project.json`); add
+      `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` as GitHub Actions repository secrets.
+
+---
+
+## Phase 2: Foundational — reproducible, self-contained build (issue #24)
+
+**Purpose**: make the build deterministic and offline-safe. **⚠️ Blocks US1** — no deploy is
+reliable until the build no longer depends on remote CDNs and the PDF step is awaited/fatal.
+
+- [ ] T003 [P] Vendor Bootstrap 5.2.0 CSS into `src/assets/vendor/bootstrap/` (the `bootstrap.min.css`
+      currently loaded from jsDelivr)
+- [ ] T004 [P] Vendor Font Awesome 6.1.2 (CSS + `webfonts/`) into `src/assets/vendor/fontawesome/`
+      (currently loaded from cdnjs)
+- [ ] T005 [P] Vendor Roboto 400/500 (`woff2` + an `@font-face` CSS) into `src/assets/vendor/roboto/`
+      (currently loaded from Google Fonts)
+- [ ] T006 Update `src/templates/index.html`: replace the CDN `<link>`s (Google Fonts preconnect +
+      Roboto, Bootstrap, Font Awesome) with references to the vendored files under `assets/vendor/`
+- [ ] T007 Update `src/utils/pdf.js`: use `waitUntil: 'load'`, `await page.evaluate(() =>
+      document.fonts.ready)` before `page.pdf()`, and set an explicit `page.goto` timeout
+- [ ] T008 Update `src/build.js`: wrap the build body in an async IIFE, `await buildPdf(...)`, and
+      `.catch(err => { console.error(err); process.exit(1) })` so a PDF failure fails the build
+      (currently `buildPdf` is called unawaited)
+- [ ] T009 Verify offline reproducibility: run `make page` with CDN/network access blocked → HTML +
+      correctly-fonted PDF produced; `grep "https://" dist/index.html` shows no font/CSS CDN links
+      (quickstart Scenario 1 / SC-003)
+
+**Checkpoint**: the build is deterministic and offline-safe — US1 can begin.
+
+---
+
+## Phase 3: User Story 1 — platform builds & serves (Priority: P1) 🎯 MVP
+
+**Goal**: every push produces a working deployment (production from `main`, preview per PR) serving
+HTML + PDF, with automatic TLS — no manual server/cert steps.
+
+**Independent Test**: open a PR → a preview URL serves the page + PDF over HTTPS; merge to `main` →
+production deploy aliased to the project domain (quickstart Scenarios 2–3).
+
+- [ ] T010 [US1] Add `vercel.json` at repo root: `framework: null`, `buildCommand: ""`,
+      `outputDirectory: "dist"`, `cleanUrls: true`, `trailingSlash: false`,
+      `git.deploymentEnabled: false`, and the `headers` (Cache-Control per type + security headers)
+      from `contracts/serving-contract.md`; add `.vercel/` to `.gitignore`
+- [ ] T011 [US1] Add a `deploy` target to `Makefile` wrapping `vercel pull` → `vercel build` →
+      `vercel deploy --prebuilt` (reading `VERCEL_*` from the env; `--prod` when `PROD=1`); add
+      `deploy` to `.PHONY`
+- [ ] T012 [US1] Add `.github/workflows/deploy.yml`: trigger on `push` to `main` (production) and
+      `pull_request` (preview); steps = Node 22 + `npm ci`, cache `~/.cache/ms-playwright` (keyed on
+      the Playwright version + runner OS), `npx playwright install --with-deps chromium`,
+      `make page`, then `make deploy` (`PROD=1` on `main`)
+- [ ] T013 [US1] In `deploy.yml`, capture the deploy URL from stdout and post it to the PR
+      (`actions/github-script` or `gh pr comment`) so preview URLs are visible (FR-002)
+- [ ] T014 [US1] Verify: PR → workflow builds + posts a working preview URL (HTML + PDF, correct
+      fonts, `/<slug>.pdf` reachable); a forced build failure promotes nothing (FR-008); prod path
+      aliases correctly (quickstart Scenarios 2–3 / SC-001, SC-002)
+
+**Checkpoint**: the site builds and serves from Vercel on every push. MVP complete — deployable.
+
+---
+
+## Phase 4: User Story 2 — domain cutover (Priority: P2)
+
+**Goal**: `valerio.dev` (canonical) + `www` serve from Vercel over auto-managed TLS; `www` 301s to
+apex. Restores the currently-down site. **Depends on US1** (a working prod deploy must exist).
+
+**Independent Test**: `dig`/`curl` show apex served over valid TLS and `www` → 301 → apex
+(quickstart Scenario 4).
+
+- [ ] T015 [US2] Write the DNS cutover runbook in `docs/` (e.g. a "Domain cutover" section of
+      `docs/ci-cd.md`): lower TTL → add domains in Vercel → set `www` → 301 → apex → verify serving +
+      cert **before** switching → set A/CNAME → verify. Note there is no rollback (VM already down).
+- [ ] T016 [US2] **(owner-run — Vercel dashboard)** Add `valerio.dev` + `www.valerio.dev` to the
+      project; mark `valerio.dev` primary; set `www.valerio.dev` "Redirect to" the apex (301)
+- [ ] T017 [US2] **(owner-run — DNS registrar)** Set apex `A → <IP from Vercel Domain settings>` and
+      `www CNAME → <project>.vercel-dns-###.com` (exact values from the dashboard); lower TTL first
+- [ ] T018 [US2] Verify cutover: `dig A valerio.dev` matches the dashboard IP; `curl -sI
+      https://valerio.dev/` → 200 + valid TLS; `curl -sI https://www.valerio.dev/` → 301 → apex
+      (quickstart Scenario 4 / SC-004, SC-005, FR-006, FR-007)
+
+**Checkpoint**: the live site is restored on `valerio.dev` via Vercel.
+
+---
+
+## Phase 5: User Story 3 — retire the manual VM stack (Priority: P3)
+
+**Goal**: remove the dead deploy machinery + retired Makefile targets and update docs. **Only after
+US2 is verified.** (VM already powered down — no decommission step.)
+
+**Independent Test**: no `webserver`/`certbot`/`nginx` targets remain; docker-compose/config gone;
+`make page` / `make lint` / `make dev-build` / `npm start` still work (quickstart Scenario 5).
+
+- [ ] T019 [P] [US3] Remove `docker-compose.yml` (app-builder + nginx + certbot services) and
+      `config/nginx/`
+- [ ] T020 [US3] Remove the retired deploy targets from `Makefile` (`webserver*`, `certificates*`,
+      `logs-*`, `remove-*`, `build`, `down`, `all`); keep `clean`, `dev`, `page`, `lint`,
+      `lint-fast`, `dev-build`, `deploy`
+- [ ] T021 [US3] Decouple `Dockerfile` + `make dev-build` from the removed docker-compose so the
+      no-local-node build still works (FR-011)
+- [ ] T022 [P] [US3] Remove the dead `predeploy` (gh-pages) script from `package.json`
+- [ ] T023 [US3] Verify retirement (quickstart Scenario 5): retired targets gone; `make page`,
+      `make lint`, `make dev-build`, `npm start` all still work (FR-010, FR-011)
+
+**Checkpoint**: only the Vercel deploy path remains; local dev intact.
+
+---
+
+## Phase 6: Polish & docs sync
+
+**Purpose**: bring all docs in line with the new model (constitution Principle III) and final-verify.
+
+- [ ] T024 [P] Rewrite `docs/ci-cd.md`: CD is now GitHub Actions → Vercel prebuilt deploy; remove
+      the manual VM/nginx/certbot deploy sections
+- [ ] T025 [P] Update `docs/architecture.md`: replace the nginx/certbot/app-builder "deploy stack"
+      description with Vercel hosting
+- [ ] T026 [P] Update `README.md`: replace the GitHub Pages / `npm run deploy` + VM instructions with
+      the Vercel push-to-deploy model; refresh usage/badges
+- [ ] T027 [P] Update `AGENTS.md`: Overview + Building/Deploy sections → Vercel CD (retire the
+      manual-deploy language)
+- [ ] T028 Add an ADR in `docs/adr/` recording the decision: build in CI + deploy prebuilt to Vercel
+      (not native Vercel build), apex-canonical, and vendored fonts (#24)
+- [ ] T029 Final verification: run through `quickstart.md` Scenarios 1–5 and `make lint`
+      (Super-Linter) green (SC-006, SC-007)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (Phase 1)**: owner-run; no code dependencies. Do before US1's workflow can deploy.
+- **Foundational (Phase 2)**: **blocks US1** — the build must be reproducible/offline first.
+- **US1 (Phase 3)**: after Setup + Foundational.
+- **US2 (Phase 4)**: **after US1** (needs a working production deploy to cut over to).
+- **US3 (Phase 5)**: **after US2 verified** (retire the VM stack only once Vercel is authoritative).
+- **Polish (Phase 6)**: after the stories it documents (ci-cd/architecture/README/AGENTS + ADR).
+
+### Sequentiality note
+
+Unlike a typical multi-story feature, US1 → US2 → US3 must proceed **in order** (each depends on the
+prior being live/verified). Within a phase, `[P]` tasks touch different files and can run together.
+
+### Parallel opportunities
+
+- **Phase 2**: T003, T004, T005 (three independent vendored dependencies) in parallel; then T006–T008.
+- **Phase 5**: T019 and T022 in parallel.
+- **Phase 6**: T024–T027 (four independent doc files) in parallel.
+
+---
+
+## Implementation strategy
+
+### MVP (US1)
+
+1. Phase 1 Setup (owner credentials + disconnect Git) → 2. Phase 2 Foundational (reproducible build)
+→ 3. Phase 3 US1 (vercel.json + workflow + `make deploy`) → **validate**: PR preview + prod deploy
+serve HTML + PDF. This is the deployable MVP — the site builds and serves on Vercel (on the
+`*.vercel.app` URL) even before the custom-domain cutover.
+
+### Incremental delivery
+
+US1 (builds/serves) → US2 (domain cutover — site live on `valerio.dev`) → US3 (retire the VM stack) →
+Polish (docs + ADR). Each increment is independently verifiable via its quickstart scenario.
+
+---
+
+## Notes
+
+- `[P]` = different files, no dependency on an incomplete task.
+- Owner-run tasks (T001, T002, T016, T017) happen in the Vercel dashboard / DNS registrar and are not
+  repo edits — the agent cannot perform them.
+- Each task ≥10 reviewable lines triggers the self-review gate (`/code-review`) before its PR.
+- Commit per task or logical group; keep docs in sync in the same PR (Principle III).


### PR DESCRIPTION
## Summary
The spec-kit **planning baseline** for the Vercel hosting/CD migration — the source of intent that the per-phase implementation PRs build on. No behavior change; docs only under `specs/001-vercel-cd-migration/`.

## Contents
- `spec.md` (clarified), `plan.md`, `tasks.md` (29 tasks), `research.md`, `data-model.md`, `contracts/` (serving + deploy), `quickstart.md`, `checklists/`.

## Decision (from plan/research)
Build the site incl. the PDF in **GitHub Actions** with the pinned Playwright Chromium, then **`vercel deploy --prebuilt`** to Vercel (Vercel's own git build disabled); apex `valerio.dev` canonical, `www` 301; vendor CDN fonts (#24) for reproducible builds.

## Tracking
Implementation is tracked as the 29 issues under milestone **#3** (`phase:*` labels). Implementation lands in follow-up per-phase PRs that `Closes` those issues. This PR itself only adds the planning docs.

## Review
Spec and plan each went through an independent review round (findings fixed); `/speckit-analyze` reported 100% task coverage, 0 critical issues.