### PR TITLE
Self-contained build: vendor fonts/CSS + harden PDF pipeline (#24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
       "name": "cv",
       "license": "MIT",
       "devDependencies": {
+        "@fontsource/roboto": "^5.2.10",
+        "@fortawesome/fontawesome-free": "^6.1.2",
+        "bootstrap": "^5.2.0",
         "chokidar-cli": "^3.0.0",
         "dayjs": "^1.11.4",
         "fs-extra": "^10.1.0",
@@ -273,6 +276,27 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.10.tgz",
+      "integrity": "sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
+      "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -369,6 +393,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -917,6 +953,26 @@
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.5"
       }
     },
     "node_modules/brace-expansion": {
@@ -9930,6 +9986,18 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true
     },
+    "@fontsource/roboto": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.10.tgz",
+      "integrity": "sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==",
+      "dev": true
+    },
+    "@fortawesome/fontawesome-free": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
+      "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -9995,6 +10063,13 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "dev": true,
+      "peer": true
     },
     "@rtsao/scc": {
       "version": "1.1.0",
@@ -10393,6 +10468,13 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "bootstrap": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "dev": true,
+      "requires": {}
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "homepage": "https://github.com/brunogbv/cv#readme",
   "devDependencies": {
+    "@fontsource/roboto": "^5.2.10",
+    "@fortawesome/fontawesome-free": "^6.1.2",
+    "bootstrap": "^5.2.0",
     "chokidar-cli": "^3.0.0",
     "dayjs": "^1.11.4",
     "fs-extra": "^10.1.0",

--- a/src/build.js
+++ b/src/build.js
@@ -11,26 +11,53 @@ const path = require('path')
 
 const srcDir = __dirname
 const outputDir = path.join(__dirname, '/../dist')
+const nodeModules = path.join(__dirname, '/../node_modules')
 
-// Clear dist dir
-fs.emptyDirSync(outputDir)
+// Vendored CSS/fonts copied from pinned node_modules into dist/ so the page and PDF render with no
+// third-party CDN at build/render time (issue #24). [from, to-relative-to-dist]
+const vendoredAssets = [
+  ['bootstrap/dist/css/bootstrap.min.css', 'vendor/bootstrap/bootstrap.min.css'],
+  ['@fortawesome/fontawesome-free/css/all.min.css', 'vendor/fontawesome/css/all.min.css'],
+  ['@fortawesome/fontawesome-free/webfonts', 'vendor/fontawesome/webfonts'],
+  ['@fontsource/roboto/latin-400.css', 'vendor/roboto/latin-400.css'],
+  ['@fontsource/roboto/latin-500.css', 'vendor/roboto/latin-500.css'],
+  ['@fontsource/roboto/files/roboto-latin-400-normal.woff2', 'vendor/roboto/files/roboto-latin-400-normal.woff2'],
+  ['@fontsource/roboto/files/roboto-latin-400-normal.woff', 'vendor/roboto/files/roboto-latin-400-normal.woff'],
+  ['@fontsource/roboto/files/roboto-latin-500-normal.woff2', 'vendor/roboto/files/roboto-latin-500-normal.woff2'],
+  ['@fontsource/roboto/files/roboto-latin-500-normal.woff', 'vendor/roboto/files/roboto-latin-500-normal.woff']
+]
 
-// Copy assets
-fs.copySync(srcDir + '/assets', outputDir)
+async function build () {
+  // Clear dist dir
+  fs.emptyDirSync(outputDir)
 
-// Build HTML
-handlebars.registerHelper('markdown', markdownHelper)
-const source = fs.readFileSync(srcDir + '/templates/index.html', 'utf-8')
-const template = handlebars.compile(source)
-const pdfFileName = `${getSlug(templateData.name)}.${getSlug(templateData.title)}.pdf`
-const html = template({
-  ...templateData,
-  baseUrl: 'https://valerio.dev',
-  pdfFileName,
-  updated: dayjs().format('MMMM D, YYYY')
+  // Copy assets
+  fs.copySync(srcDir + '/assets', outputDir)
+
+  // Copy vendored CSS/fonts from node_modules (fail loudly if a pinned dependency is missing)
+  for (const [from, to] of vendoredAssets) {
+    fs.copySync(path.join(nodeModules, from), path.join(outputDir, to))
+  }
+
+  // Build HTML
+  handlebars.registerHelper('markdown', markdownHelper)
+  const source = fs.readFileSync(srcDir + '/templates/index.html', 'utf-8')
+  const template = handlebars.compile(source)
+  const pdfFileName = `${getSlug(templateData.name)}.${getSlug(templateData.title)}.pdf`
+  const html = template({
+    ...templateData,
+    baseUrl: 'https://valerio.dev',
+    pdfFileName,
+    updated: dayjs().format('MMMM D, YYYY')
+  })
+
+  fs.writeFileSync(outputDir + '/index.html', html)
+
+  // Build PDF (awaited so a render failure aborts the build)
+  await buildPdf(`${outputDir}/index.html`, `${outputDir}/${pdfFileName}`)
+}
+
+build().catch((err) => {
+  console.error(err)
+  process.exit(1)
 })
-
-fs.writeFileSync(outputDir + '/index.html', html)
-
-// Build PDF
-buildPdf(`${outputDir}/index.html`, `${outputDir}/${pdfFileName}`)

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ name }}. {{ title }}</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"> -->
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css">
+    <!-- Vendored, self-contained CSS/fonts (copied from pinned node_modules at build time) — no CDN at render time (#24) -->
+    <link rel="stylesheet" href="vendor/roboto/latin-400.css">
+    <link rel="stylesheet" href="vendor/roboto/latin-500.css">
+    <link rel="stylesheet" href="vendor/bootstrap/bootstrap.min.css">
+    <link rel="stylesheet" href="vendor/fontawesome/css/all.min.css">
     <link rel="stylesheet" href="styles.css">
     <base target="_blank">
 </head>

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -4,19 +4,32 @@ module.exports = async function buildPdf (inputFile, outputFile) {
   const browser = await chromium.launch({
     args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
   })
-  const page = await browser.newPage()
-  await page.goto(`file://${inputFile}`, {
-    waitUntil: 'networkidle'
-  })
-  await page.pdf({
-    path: outputFile,
-    format: 'A4',
-    margin: {
-      top: '2.54cm',
-      right: '2.54cm',
-      bottom: '2.54cm',
-      left: '2.54cm'
-    }
-  })
-  await browser.close()
+  try {
+    const page = await browser.newPage()
+    // Assets are vendored locally (issue #24), so 'load' is sufficient and the explicit timeout
+    // makes a missing/slow resource fail fast instead of hanging.
+    await page.goto(`file://${inputFile}`, {
+      waitUntil: 'load',
+      timeout: 30000
+    })
+    // Ensure the vendored web fonts are parsed and applied before rendering so the PDF never falls
+    // back to default fonts. Bounded so a stalled font load fails the build instead of hanging.
+    await page.evaluate(() => Promise.race([
+      document.fonts.ready,
+      new Promise((resolve, reject) => setTimeout(() => reject(new Error('fonts not ready within 10s')), 10000))
+    ]).then(() => undefined))
+    await page.pdf({
+      path: outputFile,
+      format: 'A4',
+      margin: {
+        top: '2.54cm',
+        right: '2.54cm',
+        bottom: '2.54cm',
+        left: '2.54cm'
+      }
+    })
+  } finally {
+    // Always release the browser, even if navigation/render throws.
+    await browser.close()
+  }
 }


### PR DESCRIPTION
## Summary
Foundational phase of the Vercel migration (milestone #3): make the build **reproducible and self-contained** so it no longer depends on third-party CDNs at render time (issue #24). This is the prerequisite for reliable Vercel/CI builds.

## Changes
- **Vendored deps** (pinned devDependencies, copied into `dist/vendor/` at build time by `src/build.js`): Bootstrap 5.2.0, Font Awesome 6.1.2 (CSS + webfonts), Roboto 400/500 (`@fontsource/roboto`, latin subset).
- **`src/templates/index.html`**: replaced the Google Fonts / jsDelivr / cdnjs `<link>`s with local `vendor/…` references (dropped the now-pointless preconnect hints).
- **`src/utils/pdf.js`**: `waitUntil: 'load'` + explicit 30s `goto` timeout; bounded `document.fonts.ready` wait (fails loud instead of hanging); `try/finally` so the browser always closes.
- **`src/build.js`**: `await buildPdf(...)` inside an async wrapper with `.catch(process.exit(1))` — a PDF/render failure now aborts the build (was fire-and-forget).

## Verification (in the Dev Container — no host toolchain)
`devcontainer exec … make page`:
- `dist/vendor/*` fully populated; **0** font/CSS CDN URLs in `dist/index.html`.
- ~316 KB PDF that **embeds** `Roboto-Regular`, `Roboto-Medium`, `FontAwesome6Free-Solid`, `FontAwesome6Brands-Regular` — correct vendored fonts, not fallbacks.

## Review
Independently reviewed (correctness + vendor wiring + removed-CDN parity): wiring fully consistent, no parity lost; 2 `pdf.js` robustness findings (unbounded font wait, browser cleanup) fixed.

Closes #37, #38, #39, #40, #41, #42, #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)