### PR TITLE
Codify: proactively propose harness improvements (+ harness label)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -35,6 +35,12 @@ Pin what determines output (Node 22, Playwright's Chromium via the lockfile); pr
 builds over emulation. Add only what is needed — minimal dependencies, minimal commands, minimal
 config.
 
+### VI. The harness is a living system
+
+When a task reveals a systemic gap in the harness (conventions, docs, `.claude/` hooks, the Dev
+Container, CI, spec-kit), codify the fix rather than patching the symptom — see
+[`docs/contributing.md`](../../docs/contributing.md) ("Improving the harness").
+
 ## Development Workflow
 
 Work is tracked in GitHub — one Milestone per shippable deliverable, its Issues tagged with
@@ -48,4 +54,4 @@ and a PR that links its issue with `Closes #<n>`.
 This constitution reflects and defers to [`AGENTS.md`](../../AGENTS.md); amendments update both and
 keep them consistent. All PRs are expected to comply, and added complexity must be justified.
 
-**Version**: 1.0.3 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-02
+**Version**: 1.1.0 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-02

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,22 @@ When a change alters behavior, commands, architecture, or workflow, update the r
 this `AGENTS.md`. A change that outdates a doc isn't done until the doc is fixed. Record
 significant, expensive-to-reverse decisions as an ADR in [`docs/adr/`](docs/adr/).
 
+## Improving the harness
+
+The **harness** — this `AGENTS.md`, the constitution, `docs/`, `.claude/` (hooks, settings, skills),
+the Dev Container, CI, and the spec-kit setup — is a living system. When resolving a task reveals a
+**systemic gap** in it (a missing convention, an undocumented assumption, or a footgun likely to
+recur — e.g. builds must run in the Dev Container not the host, or Dev Container deps not persisting),
+don't just patch it ad-hoc:
+
+- **Name the gap and ask** whether to codify the fix into the harness — prefer fixing the system over
+  the symptom. Whether to codify now, defer, or skip is the owner's call.
+- **If the owner agrees**, raise a `harness`-labeled issue (see
+  [`docs/contributing.md`](docs/contributing.md)) and handle it as its own change, separate from the
+  task that surfaced it. `harness` is a grouping **label, not a milestone** — this work is ongoing.
+
+Surface such gaps proactively rather than waiting to be asked.
+
 ## Issue Tracking
 
 Work is tracked in **GitHub Issues and Milestones** (Projects optional) — see

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -95,6 +95,27 @@ a hard gate — an ignored block eventually lets go, and it only runs for contri
 Code, so treat it as a prompt to review rather than a guarantee. Tune the threshold per-project with
 `REVIEW_GATE_THRESHOLD`.
 
+## Improving the harness
+
+The harness — the conventions in `AGENTS.md` + the constitution, `docs/`, `.claude/`
+(hooks / settings / skills), the Dev Container, CI, and the spec-kit setup — is maintained
+deliberately, not ad-hoc. When a task reveals a **systemic gap** in it (a recurring footgun, a
+missing convention, or an undocumented assumption):
+
+1. **Name it** — state the gap the specific issue revealed.
+2. **Propose codifying** — ask whether to fix the system (a convention / doc / tooling change)
+   rather than patch the symptom once. The owner decides: codify now, defer, or skip.
+3. **Track it** — if the owner agrees, raise an issue with the **`harness`** label (create it once
+   if missing) plus a type label (`documentation` for convention/doc changes, `maintenance` for
+   tooling/CI/Dev Container), and a body covering the recurring problem and the proposed
+   codification. `harness` is a grouping **label, not a milestone** — this work is ongoing.
+4. **Land it as its own change** — a focused PR separate from the task that surfaced it, keeping the
+   docs and constitution in sync (`Closes #<n>`).
+
+Examples: #68 (builds run in the Dev Container, not the host) and #70 (codifying the
+in-container-builds convention) both landed; #69 (bake Dev Container installs so they persist) is
+tracked.
+
 ## Doing it from the CLI (`gh`)
 
 Create an issue:


### PR DESCRIPTION
## Summary
Make improving the harness **proactive** instead of owner-initiated. Until now, harness gaps were spotted reactively and the owner had to prompt to codify the fix (e.g. #68 host builds, #69 dep-persistence). This adds a standing convention so the agent surfaces the gap and asks whether to codify it — turning the owner from initiator into approver.

## Changes
- **`AGENTS.md`** — new **"Improving the harness"** convention (the behavioral trigger: name the gap → ask whether to codify → raise a `harness` issue → own PR; fix the system, not the symptom).
- **`docs/contributing.md`** — the trigger → propose → label → land workflow (the canonical how-to).
- **`.specify/memory/constitution.md`** — new **Principle VI** that **points to the docs** (not a restatement, per the drift concern); version **1.0.3 → 1.1.0** (minor — adds a core principle); AGENTS.md kept consistent per governance.
- New **`harness`** label — a grouping label (not a milestone; harness work is ongoing).

## Verified
- `make lint-fast` clean **in the Dev Container**.
- Independently reviewed: cross-file consistent; constitution is a pointer with a resolving link; fixed trigger-phrasing divergence, ask→codify sequencing, and added type-label guidance.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)