### PR TITLE
make worktree: git-worktree branching off fresh origin/main (#73)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,8 @@ with a clear imperative title, a type label (`documentation` / `enhancement` / `
 **References**. Use **one milestone per shippable thing** (a deliverable/initiative) and **labels to
 tag phases** (e.g. `phase:*`) for grouping within it — not a milestone per phase. A GitHub **Project
 is optional** (a board/field view; use it for kanban/custom-field/cross-milestone tracking). Link
-PRs to issues with `Closes #<n>`.
+PRs to issues with `Closes #<n>`. Start each branch in its own git worktree off fresh `origin/main`
+with `make worktree name=<b>` — never off a stale local `main`.
 
 ## Spec-driven development
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += -s
 
-.PHONY: dev clean page page-container lint lint-fast build dev-build \
+.PHONY: dev clean page page-container worktree lint lint-fast build dev-build \
 	logs-app-builder logs-webserver logs-certbot \
 	remove-app-builder remove-certbot \
 	certificates certificates-dry-run \
@@ -30,6 +30,16 @@ page:
 page-container:
 	$(MAKE) dev
 	devcontainer exec --workspace-folder . make page
+
+# Start a new branch in an isolated git worktree, always off the fresh origin/main
+# (avoids branching on a stale local main). Usage: make worktree name=<branch>
+# Dependencies: git
+worktree:
+	test -n "$(name)" || { echo "Usage: make worktree name=<branch>  (e.g. make worktree name=fix/typo)"; exit 1; }
+	git fetch origin
+	git worktree add "../cv-$(subst /,-,$(name))" -b "$(name)" --no-track origin/main
+	echo "Worktree: ../cv-$(subst /,-,$(name))  (branch '$(name)' off origin/main)"
+	echo "Next: cd ../cv-$(subst /,-,$(name)) && make page-container   (remove later: git worktree remove ../cv-$(subst /,-,$(name)))"
 
 lint:
 	docker run --rm \

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,6 +70,21 @@ A well-formed issue has:
    the issue groups without a new milestone.
 6. **Project** *(optional)* — add it to a board only if the effort uses one.
 
+## Branching
+
+Start each change in its own **git worktree**, created off a fresh `origin/main` — this avoids the
+stale-base footgun (branching off an out-of-date local `main`) and lets branches run in parallel
+without switching:
+
+```sh
+make worktree name=fix/typo   # fetches, then creates ../cv-fix-typo on branch fix/typo off origin/main
+```
+
+Work in the new `../cv-<name>` directory (build with `make page-container`). On your first push use
+`git push -u origin <name>` — the worktree branch starts with no upstream. Remove it when done with
+`git worktree remove ../cv-<name>`. Worktrees are the standard branching workflow — always branch off
+`origin/main`, never a stale local `main`.
+
 ## Linking pull requests
 
 Reference the issue in the PR description with a closing keyword so it auto-closes on merge:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -24,6 +24,7 @@ Everything goes through the `Makefile` — run `make <target>`:
 
 | Task | Command | Notes |
 | ---- | ------- | ----- |
+| New branch (isolated worktree) | `make worktree name=<b>` | fetches + branches off `origin/main` into `../cv-<b>` |
 | Preview (build + watch + serve) | `npm start` | serves `dist/` on port 8080 (needs host Node) |
 | Build in the container (HTML + PDF) | `make page-container` | **preferred** — builds inside the Dev Container; host stays clean |
 | Build on the host (HTML + PDF) | `make page` | needs host Node + Playwright Chromium |
@@ -41,7 +42,9 @@ Edit CV **content** in `src/metadata/metadata.js`. For the architecture and buil
 
 ## Working on a change
 
-1. **Raise an issue** and branch — see [contributing.md](contributing.md).
+1. **Raise an issue**, then start the work in an isolated worktree: `make worktree name=<branch>`
+   (fetches and branches off `origin/main`, so you never build on a stale base) — see
+   [contributing.md](contributing.md).
 2. For a non-trivial feature, go **spec-first** with spec-kit (`/speckit-specify` →
    `/speckit-clarify` → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`) — see
    [spec-driven.md](spec-driven.md).


### PR DESCRIPTION
## Summary
Adopt **git worktrees** as the standard branching workflow to end the recurring **stale-base footgun** (branching off an out-of-date local `main`, which cost rework this session). Worktrees also remove branch-switch churn — parallel branches, no stash/discard.

## Changes
- **`Makefile`** — `make worktree name=<b>`: `git fetch origin && git worktree add ../cv-<b> -b <b> --no-track origin/main`. Usage guard; dir name sanitized (`fix/typo` → `../cv-fix-typo`, branch `fix/typo`); `--no-track` so the branch has no misleading upstream.
- **`docs/local-development.md`** — commands-table row + "Working on a change" step 1 use `make worktree`.
- **`docs/contributing.md`** — new **Branching** section (worktrees off `origin/main`; `git push -u` on first push; `git worktree remove` to clean up).
- **`AGENTS.md`** — Issue Tracking notes branches start in a worktree off fresh `origin/main`.

Worktrees-only (no `make branch`), per the decision on #73.

## Verified
- End-to-end: `make worktree` creates the worktree off `origin/main` with no upstream, cleanup works, and the no-arg usage guard errors correctly.
- `make lint-fast` clean in the Dev Container; independently reviewed (fixed the doc command comment + added first-push guidance).

## Note
This is the **stale-base** fix. **#69** (bake Dev Container installs into the image) is complementary — it makes spinning a Dev Container *per worktree* cheaper — but is not required for this.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)