### PR TITLE
Codify: give each issue its own PR closing keyword (#79)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,6 +93,16 @@ Reference the issue in the PR description with a closing keyword so it auto-clos
 Closes #123
 ```
 
+When a PR resolves **several** issues (e.g. a decomposed spec-kit `T00x` task set), give **each**
+one its own keyword. GitHub only applies a keyword to the **first** number that follows it, so a
+comma list like `Closes #37, #38, #39` auto-closes *only* #37 and silently leaves the rest open:
+
+```text
+Closes #37, closes #38, closes #39
+```
+
+This footgun left #38–#43 (and umbrella #24) open after #67 — they had to be closed by hand.
+
 ## Self-review before a PR
 
 Any change over **10 reviewable lines** (excluding generated files like `package-lock.json` and


### PR DESCRIPTION
## Summary

Harness fix for #79. The **Linking pull requests** convention in `docs/contributing.md` only showed the single-issue `Closes #123` form. GitHub applies a closing keyword to the **first issue number only** in a comma list, so `Closes #37, #38, #39` auto-closes just #37 — which is exactly why #38–#43 (and umbrella #24) stayed open after #67 and had to be closed by hand.

## Changes

- `docs/contributing.md` → **Linking pull requests**: document the multi-issue form (`Closes #37, closes #38, closes #39`), show a correct example, and call out the comma-list footgun with the #67 aftermath as the concrete case.

## Verification

- `markdownlint-cli2` (repo fast config): **0 errors**.
- Line lengths ≤ 97, consistent with the file's existing ~100-col wrapping; MD013 is disabled in CI.
- `make lint` (full Super-Linter) can't run on this arm64 host — Super-Linter publishes no arm64 image; the check runs on x86 in CI.

## Scope

Docs-only, 10 lines. `AGENTS.md`'s PR-linking one-liner ("Link PRs to issues with \`Closes #<n>\`") stays correct as-is — the detailed convention lives in `contributing.md`, so no change needed there.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)