### PR TITLE
Bake Dev Container tools into the image; slim postCreate (#69)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+# Dev Container image for the CV repo.
+#
+# Bakes the heavy, workspace-INDEPENDENT tooling into the image so it persists across container
+# rebuilds and is cheap per git worktree. Workspace-specific dependencies (node_modules) stay in
+# postCreate. See docs/local-development.md.
+FROM mcr.microsoft.com/devcontainers/javascript-node:22-bookworm
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# The Dev Container runs as root by design (devcontainer.json sets remoteUser: root), and the build
+# steps below need root (apt via playwright --with-deps, global npm/uv installs).
+# hadolint ignore=DL3002
+USER root
+
+# uv + the spec-kit `specify` CLI (workspace-independent). uv's standalone installer needs no Python.
+RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh \
+  && UV_TOOL_BIN_DIR=/usr/local/bin uv tool install \
+    --from git+https://github.com/github/spec-kit.git specify-cli
+
+# Claude Code CLI (workspace-independent global).
+# hadolint ignore=DL3016
+RUN npm install -g @anthropic-ai/claude-code
+
+# Playwright's pinned Chromium + its OS dependencies, matching this repo's playwright version.
+# The browser lives at a user-independent path so it is found regardless of the container user and
+# persists across container rebuilds. Copy only the manifests so this layer caches unless the
+# lockfile changes. On a Playwright version bump the repo's playwright re-downloads the browser in
+# postCreate onto these baked OS deps; rebuild the image (`devcontainer up --build`) only if a new
+# version ever needs additional OS libraries.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+WORKDIR /tmp/pw
+COPY package.json package-lock.json ./
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci \
+  && npx --yes playwright install --with-deps chromium \
+  && rm -rf node_modules
+WORKDIR /workspaces

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "name": "cv",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/python:1": {
@@ -35,6 +38,6 @@
       }
     }
   },
-  "postCreateCommand": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci && npx --yes playwright install --with-deps chromium && pip install --root-user-action=ignore uv && { UV_TOOL_BIN_DIR=/usr/local/bin uv tool install --from git+https://github.com/github/spec-kit.git specify-cli || echo 'WARN: spec-kit install failed (non-fatal); install later with: uv tool install --from git+https://github.com/github/spec-kit.git specify-cli'; } && { npm install -g @anthropic-ai/claude-code || echo 'WARN: Claude Code CLI install failed (non-fatal)'; }",
+  "postCreateCommand": "npm ci && npx --yes playwright install chromium",
   "remoteUser": "root"
 }

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -15,6 +15,13 @@ You get Node 22, the Playwright Chromium (for the PDF), Docker access, Python + 
 `root` with host Docker access, and `.claude/settings.json` pre-approves common read-only commands
 so agents hit fewer permission prompts.
 
+**How the image is built (convention):** `.devcontainer/Dockerfile` **bakes the heavy,
+workspace-independent tooling into the image** — the Playwright Chromium (+ its OS deps), the
+spec-kit `specify` CLI, and the Claude Code CLI — so they persist across container rebuilds and are
+cheap to spin up per git worktree. `postCreate` runs only workspace-specific steps (`npm ci`, plus a
+Chromium no-op that just re-downloads if the pinned Playwright version changes). When adding Dev
+Container tooling, **put workspace-independent installs in the Dockerfile, not `postCreate`.**
+
 > Without a Dev Container you can build with just Node + npm (`npm ci`), but you'll also need a
 > Chromium for the PDF and Docker for `make lint` / `make build`. The container is the supported path.
 


### PR DESCRIPTION
## Summary
Bake the heavy, workspace-independent Dev Container installs into an image so they persist across container rebuilds and are cheap per git worktree; slim `postCreate` to workspace-specific steps. Also codifies the "bake into the image" pattern (per the "Improving the harness" convention).

## Changes
- **`.devcontainer/Dockerfile`** (new) — bakes `uv` + spec-kit (`specify`), the Claude Code CLI, and Playwright's pinned Chromium + `--with-deps` OS libraries. Browser at **`PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`** (user-independent, so it survives a future `remoteUser` change). hadolint clean.
- **`.devcontainer/devcontainer.json`** — `image` → `build.dockerfile` (repo-root context); `postCreate` slimmed to `npm ci && npx playwright install chromium` (a no-op unless the pinned Playwright version changes).
- **`docs/local-development.md`** — codified the convention: workspace-independent tooling goes in the Dockerfile, not `postCreate`.

## Verified (in a container off the built image)
- **Rebuild persistence** — a *fresh* container has the tools + Chromium with **zero setup** (no re-download).
- `make page` → correct HTML + PDF (Roboto + Font Awesome embedded, **0 CDN links**); `npm ci` ~18 s; hadolint clean.

## Notes / deferred
- Left the `python` devcontainer feature in place — now vestigial (uv is standalone) but harmless; removing it would churn the "Python + uv" docs. Minor future cleanup.
- Follow-ups already tracked from this work: **#75** (gate ↔ worktree), **#76** (per-worktree node_modules volume), **#77** (base-image digest pin), **#78** (CI image prebuild).

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)