### PR TITLE
Make the self-review gate worktree-aware (#75)

### DIFF
--- a/.claude/hooks/review-gate.sh
+++ b/.claude/hooks/review-gate.sh
@@ -4,9 +4,19 @@
 #
 # Blocks finishing a turn when the reviewable diff (excluding generated files)
 # exceeds THRESHOLD changed lines and this exact diff has not been recorded as
-# reviewed. To clear it: run /code-review, address the findings, then record:
+# reviewed. To clear it, run /code-review, address the findings, then record the
+# diff. The block message prints the exact command, which is one of:
 #
-#     bash <this-script> record
+#     bash <this-script> record          # records the current directory's worktree
+#     bash <this-script> record <dir>    # records the worktree containing <dir>
+#
+# Worktrees: with the `make worktree` workflow, edits land in a sibling worktree
+# (../cv-<name>) while the session's cwd stays in the main checkout — which then
+# has no diff. So the gate measures every worktree this session edited
+# (discovered from the transcript's file-editing tool calls) plus the current
+# directory's worktree, and records/clears each worktree independently by its
+# own root. It does NOT scan unrelated worktrees, so another session's WIP can't
+# block this turn.
 #
 # Threshold is 10 by default; override per-project with REVIEW_GATE_THRESHOLD
 # (non-integer values are ignored). Requires git and jq; without either the gate
@@ -32,50 +42,76 @@ EXCLUDES=(
   ':(exclude)**/*.min.js'         ':(exclude)**/*.min.css'
 )
 
-# Not a git repo → nothing to gate.
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
-
-# What to diff against:
+# reviewable_for <dir> — for the git worktree containing <dir>, set globals
+# RG_CHANGED (reviewable changed-line count), RG_HASH (diff hash) and RG_ROOT
+# (worktree root). Returns non-zero if <dir> is not inside a work tree.
+#
+# What it diffs against, per worktree:
 #   - unborn HEAD (fresh repo, no commit yet) → staged work (--cached)
 #   - otherwise → merge-base with the default branch (captures branch commits +
 #     uncommitted; on the default branch this collapses to HEAD, i.e. uncommitted)
-if git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
-  base=""
-  for r in origin/HEAD origin/main origin/master main master; do
-    if git rev-parse --verify --quiet "$r" >/dev/null 2>&1; then
-      base="$(git merge-base HEAD "$r" 2>/dev/null)"
-      break
-    fi
-  done
-  [ -z "$base" ] && base="HEAD"
-  diffbase=("$base")
-else
-  diffbase=(--cached)
-fi
+reviewable_for() {
+  local dir="$1" base r diffbase
+  RG_CHANGED=0; RG_HASH=""; RG_ROOT=""
+  RG_ROOT="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [ -n "$RG_ROOT" ] || return 1
+  if git -C "$RG_ROOT" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+    base=""
+    for r in origin/HEAD origin/main origin/master main master; do
+      if git -C "$RG_ROOT" rev-parse --verify --quiet "$r" >/dev/null 2>&1; then
+        base="$(git -C "$RG_ROOT" merge-base HEAD "$r" 2>/dev/null)"
+        break
+      fi
+    done
+    [ -z "$base" ] && base="HEAD"
+    diffbase="$base"
+  else
+    diffbase="--cached"
+  fi
+  RG_CHANGED="$(git -C "$RG_ROOT" diff --numstat "$diffbase" -- . "${EXCLUDES[@]}" 2>/dev/null \
+    | awk '{a+=$1; d+=$2} END {print a+d+0}')"
+  [ -z "$RG_CHANGED" ] && RG_CHANGED=0
+  RG_HASH="$(git -C "$RG_ROOT" diff "$diffbase" -- . "${EXCLUDES[@]}" 2>/dev/null | git hash-object --stdin 2>/dev/null)"
+  return 0
+}
 
-changed="$(git diff --numstat "${diffbase[@]}" -- . "${EXCLUDES[@]}" 2>/dev/null \
-  | awk '{a+=$1; d+=$2} END {print a+d+0}')"
-[ -z "$changed" ] && changed=0
+# marker_for <root> — echoes the marker file path for a worktree root. Keyed by
+# the root path so each worktree records/clears independently.
+marker_for() {
+  local key
+  key="$(printf '%s' "$1" | git hash-object --stdin 2>/dev/null | cut -c1-16)"
+  printf '%s/.claude/.review-markers/%s' "$HOME" "$key"
+}
 
-diff_hash="$(git diff "${diffbase[@]}" -- . "${EXCLUDES[@]}" 2>/dev/null | git hash-object --stdin 2>/dev/null)"
-
-root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-key="$(printf '%s' "$root" | git hash-object --stdin 2>/dev/null | cut -c1-16)"
-marker="$HOME/.claude/.review-markers/$key"
-
-# record mode: stamp the current reviewable diff as reviewed.
+# record mode: stamp a worktree's current reviewable diff as reviewed.
+#   record        → the current directory's worktree
+#   record <dir>  → the worktree containing <dir>
+# Runs before the cwd git-repo check below so it still works when invoked from a
+# non-repo cwd against a worktree path — it validates its own target instead.
 if [ "${1:-}" = "record" ]; then
+  target="${2:-$PWD}"
+  if ! reviewable_for "$target"; then
+    echo "Not inside a git worktree: $target" >&2
+    exit 0
+  fi
   mkdir -p "$HOME/.claude/.review-markers"
-  printf '%s\n' "$diff_hash" > "$marker"
-  echo "Recorded self-review for ${changed} reviewable line(s)."
+  if ! printf '%s\n' "$RG_HASH" > "$(marker_for "$RG_ROOT")"; then
+    echo "Failed to write review marker under $HOME/.claude/.review-markers" >&2
+    exit 0
+  fi
+  echo "Recorded self-review for ${RG_CHANGED} reviewable line(s) in ${RG_ROOT}."
   exit 0
 fi
+
+# Not a git repo (from cwd) → nothing to gate.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
 # Hook mode needs jq (payload parse + JSON output); without it, no-op (fail open).
 command -v jq >/dev/null 2>&1 || exit 0
 
 # Read the hook payload from stdin.
-stop_active="$(cat 2>/dev/null | jq -r '.stop_hook_active // false' 2>/dev/null)"
+payload="$(cat 2>/dev/null)"
+stop_active="$(printf '%s' "$payload" | jq -r '.stop_hook_active // false' 2>/dev/null)"
 
 # Already re-prompted once this stop-cycle → don't loop.
 [ "$stop_active" = "true" ] && exit 0
@@ -84,6 +120,7 @@ stop_active="$(cat 2>/dev/null | jq -r '.stop_hook_active // false' 2>/dev/null)
 # the project copy so we don't emit a duplicate block. Resolve the project dir
 # from CLAUDE_PROJECT_DIR, falling back to the git root.
 self="${BASH_SOURCE[0]}"
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 proj_dir="${CLAUDE_PROJECT_DIR:-$root}"
 case "$self" in
   "$HOME/.claude/hooks/review-gate.sh")
@@ -91,13 +128,50 @@ case "$self" in
     ;;
 esac
 
-# Under threshold → allow.
-[ "$changed" -le "$THRESHOLD" ] 2>/dev/null && exit 0
+# Build the set of worktrees to gate: the current directory's worktree, plus the
+# worktree of every file edited this session (read from the transcript). This
+# covers the git-worktree workflow, where edits land in a sibling worktree while
+# cwd stays in the main checkout.
+TARGETS=()
+add_target() {
+  local r="$1" t
+  [ -n "$r" ] || return
+  for t in "${TARGETS[@]}"; do [ "$t" = "$r" ] && return; done
+  TARGETS+=("$r")
+}
 
-# This exact diff already recorded as reviewed → allow.
-[ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$diff_hash" ] && exit 0
+add_target "$root"
 
-# Otherwise block and ask for a review.
-reason="Self-review required before finishing: ${changed} reviewable lines changed (threshold ${THRESHOLD}) and this diff has not been reviewed. Run /code-review, address the findings, then record it:  bash \"$self\" record"
+transcript_path="$(printf '%s' "$payload" | jq -r '.transcript_path // empty' 2>/dev/null)"
+if [ -n "$transcript_path" ] && [ -f "$transcript_path" ]; then
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    case "$p" in /*) ;; *) continue ;; esac   # tool file paths are absolute; skip anything else
+    r="$(git -C "$(dirname "$p")" rev-parse --show-toplevel 2>/dev/null)"
+    add_target "$r"
+  done < <(jq -rR 'fromjson? | .message.content[]?
+                     | select(.type? == "tool_use")
+                     | select((.name? // "") | test("^(Edit|Write|MultiEdit|NotebookEdit)$"))
+                     | (.input.file_path // .input.notebook_path // empty)' \
+             "$transcript_path" 2>/dev/null | sort -u)
+fi
+
+# Collect worktrees whose reviewable diff exceeds the threshold and whose current
+# diff has not been recorded as reviewed.
+blocks=""
+for wt in "${TARGETS[@]}"; do
+  reviewable_for "$wt" || continue
+  [ "$RG_CHANGED" -le "$THRESHOLD" ] 2>/dev/null && continue
+  m="$(marker_for "$RG_ROOT")"
+  [ -f "$m" ] && [ "$(cat "$m" 2>/dev/null)" = "$RG_HASH" ] && continue
+  blocks+="  - ${RG_CHANGED} reviewable lines in ${RG_ROOT}"$'\n'
+  blocks+="      record after review:  bash \"$self\" record \"$RG_ROOT\""$'\n'
+done
+
+# Nothing over threshold and unreviewed → allow.
+[ -z "$blocks" ] && exit 0
+
+reason="Self-review required before finishing. Unreviewed changes over the threshold (${THRESHOLD} lines):
+${blocks}Run /code-review, address the findings, then record each worktree with the command shown above."
 jq -cn --arg r "$reason" '{decision:"block", reason:$r}'
 exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,11 @@ self-review and act on it:
 - Fix confirmed findings; state explicitly anything you deliberately defer.
 
 This is enforced by a `Stop` hook (`.claude/hooks/review-gate.sh`) that blocks finishing until the
-current diff is recorded as reviewed. After reviewing, record it (the block message prints the
-exact command): `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/review-gate.sh" record`.
+current diff is recorded as reviewed. The gate is worktree-aware: it measures each worktree you
+edited this turn (plus the current directory's) and records/clears each by its own root, so it fires
+for work done in a `make worktree` sibling — not just the main checkout. After reviewing, record it
+with the command the block message prints (it names the worktree):
+`bash "$CLAUDE_PROJECT_DIR/.claude/hooks/review-gate.sh" record "<worktree>"`.
 
 ## Keep docs in sync
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -111,14 +111,23 @@ Any change over **10 reviewable lines** (excluding generated files like `package
 1. Run `/code-review` in Claude Code — it spawns independent reviewers that critique the diff
    (correctness, removed behavior, robustness) and verify findings.
 2. Fix the confirmed findings; note anything you deliberately defer.
-3. Record the review so the gate clears (the block message prints the exact command):
-   `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/review-gate.sh" record`
+3. Record the review so the gate clears. **Copy the exact command from the block message** rather
+   than typing it — it names the worktree to record (see below):
+   `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/review-gate.sh" record "<worktree>"`
 
 A `Stop` hook (`.claude/hooks/review-gate.sh`) enforces this locally for Claude Code users: it
 blocks finishing a turn until the current diff is recorded as reviewed. It is a strong reminder, not
 a hard gate — an ignored block eventually lets go, and it only runs for contributors using Claude
 Code, so treat it as a prompt to review rather than a guarantee. Tune the threshold per-project with
 `REVIEW_GATE_THRESHOLD`.
+
+**Worktrees.** Because work happens in a sibling worktree (`make worktree`) while the session's cwd
+stays in the main checkout, the gate measures **each worktree you edited this turn** (found from the
+transcript) plus the current directory's worktree, and records/clears each one **by its own root**.
+So the block message's `record "<worktree>"` targets the worktree where the change lives — run it as
+shown, or from inside the worktree as `bash …/review-gate.sh record`. Unrelated worktrees (another
+task's WIP) are never scanned, so they can't block your turn. Only tracked changes count — a
+brand-new file is measured once it's `git add`ed.
 
 ## Improving the harness
 


### PR DESCRIPTION
## Summary

Fixes #75. The self-review `Stop` hook (`.claude/hooks/review-gate.sh`) measured the diff in the process cwd — the main checkout (`$CLAUDE_PROJECT_DIR`). With the `make worktree` workflow (#73/#74), edits land in a **sibling worktree** while the main checkout stays clean, so the gate saw no diff and **silently didn't fire** for what is now the standard workflow. `record` had the same blind spot.

## Approach

The hook now gates **every worktree this turn actually touched**, not just the main checkout:

- **Discovers edited worktrees from the transcript** — parses the JSONL `transcript_path` for `Edit`/`Write`/`MultiEdit`/`NotebookEdit` tool calls, maps each file path to its worktree root (`git -C <dir> rev-parse --show-toplevel`), and adds the current directory's worktree.
- **Measures / records / clears each worktree independently**, keyed by its own root (existing per-root marker scheme, now applied per worktree).
- **No cross-contamination** — unrelated worktrees (another task's WIP) are never scanned, so they can't block your turn. Chosen over a "scan all worktrees" approach precisely to avoid that.
- **`record [dir]`** stamps a specific worktree and runs **before** the cwd git-repo check, so it works even when invoked from a non-repo cwd against a worktree path. The block message prints the exact `record "<worktree>"` command.

Behavior for main-checkout-only work is unchanged (the cwd worktree is always in the gated set), and the block decision is a strict **superset** of the old one — more gating, never less.

## Verification (scripted, all pass)

- >10-line change in a worktree **trips** the gate (block names the worktree); `record` clears it; changing the diff **re-blocks** (hash mismatch). ✅ (acceptance criteria 1, 2, 4)
- `record` works **from within a worktree** (no arg) and **by path** from elsewhere. ✅
- An unrelated sibling worktree with a big diff is **not** flagged. ✅
- Main-checkout edits still gate (backward-compat). ✅
- Loop guard (`stop_hook_active`), fail-open-without-jq, and the user-global-copy defer branch preserved. ✅
- `shellcheck` clean, `bash -n` OK, `markdownlint` clean.

## Self-review

Note: `/code-review` computes its diff from the session cwd (main checkout, on `main`, clean) — the **exact blind spot this PR fixes** — so it can't see the worktree diff. I ran the independent adversarial review explicitly against the worktree diff via three reviewer agents (correctness, removed-behavior/parity, robustness). Findings addressed:

- **[HIGH]** `record <dir>` no-op'd when the hook's cwd wasn't a git repo (cwd gate ran before the record branch) → moved record ahead of the cwd check; verified recording from `/tmp`.
- **[LOW]** `record` reported success even if the marker write failed → now checks the write and surfaces the failure.
- **[LOW]** relative transcript paths could resolve against the wrong cwd → added an absolute-path guard (tool paths are absolute in practice).
- **Deferred:** NUL-delimiting edited paths to tolerate literal newlines in filenames — purely theoretical, not worth the added complexity.

## Docs

`AGENTS.md` and `docs/contributing.md` updated for the worktree-aware behavior and the `record "<worktree>"` command form (acceptance criterion 3).

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)