### PR TITLE
Auto-prune merged git worktrees (#83)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,9 @@ with a clear imperative title, a type label (`documentation` / `enhancement` / `
 tag phases** (e.g. `phase:*`) for grouping within it — not a milestone per phase. A GitHub **Project
 is optional** (a board/field view; use it for kanban/custom-field/cross-milestone tracking). Link
 PRs to issues with `Closes #<n>`. Start each branch in its own git worktree off fresh `origin/main`
-with `make worktree name=<b>` — never off a stale local `main`.
+with `make worktree name=<b>` — never off a stale local `main`. `make worktree` first prunes
+worktrees whose PR has merged (and `make worktree-prune` does it on demand), so merged worktrees
+clean themselves up.
 
 ## Spec-driven development
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += -s
 
-.PHONY: dev clean page page-container worktree worktree-rm lint lint-fast build dev-build \
+.PHONY: dev clean page page-container worktree worktree-rm worktree-prune lint lint-fast build dev-build \
 	logs-app-builder logs-webserver logs-certbot \
 	remove-app-builder remove-certbot \
 	certificates certificates-dry-run \
@@ -32,14 +32,16 @@ page-container:
 	devcontainer exec --workspace-folder . make page
 
 # Start a new branch in an isolated git worktree, always off the fresh origin/main
-# (avoids branching on a stale local main). Usage: make worktree name=<branch>
-# Dependencies: git
+# (avoids branching on a stale local main). Prunes merged worktrees first (best
+# effort — never blocks the create). Usage: make worktree name=<branch>
+# Dependencies: git (gh optional, for the authoritative merged-PR check)
 worktree:
 	test -n "$(name)" || { echo "Usage: make worktree name=<branch>  (e.g. make worktree name=fix/typo)"; exit 1; }
+	bash scripts/worktree-prune.sh || true
 	git fetch origin
 	git worktree add "../cv-$(subst /,-,$(name))" -b "$(name)" --no-track origin/main
 	echo "Worktree: ../cv-$(subst /,-,$(name))  (branch '$(name)' off origin/main)"
-	echo "Next: cd ../cv-$(subst /,-,$(name)) && make page-container   (remove later: make worktree-rm name=$(name))"
+	echo "Next: cd ../cv-$(subst /,-,$(name)) && make page-container   (removed automatically once its PR merges — or now: make worktree-rm name=$(name))"
 
 # Remove a worktree created by `make worktree` plus its per-worktree node_modules volume (the shared
 # npm cache is kept). Stop the worktree's Dev Container first, else the volume removal is skipped.
@@ -50,6 +52,14 @@ worktree-rm:
 	git worktree remove "../cv-$(subst /,-,$(name))"
 	docker volume rm "cv-node-modules-cv-$(subst /,-,$(name))" 2>/dev/null && echo "removed node_modules volume" || echo "(node_modules volume not found or in use — stop its Dev Container, then: docker volume rm cv-node-modules-cv-$(subst /,-,$(name)))"
 	echo "Removed worktree ../cv-$(subst /,-,$(name))  (shared npm cache kept)"
+
+# Remove all sibling worktrees whose PR has merged, deleting each one's local branch and its
+# per-worktree node_modules volume (shared npm cache kept). Safe: skips the main/current worktree,
+# the default branch, and any worktree with uncommitted changes. Preview with
+# `bash scripts/worktree-prune.sh --dry-run`. Runs automatically before `make worktree`.
+# Dependencies: git (gh optional, for the authoritative merged-PR check; docker to drop volumes)
+worktree-prune:
+	bash scripts/worktree-prune.sh
 
 lint:
 	docker run --rm \

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,10 +81,27 @@ make worktree name=fix/typo   # fetches, then creates ../cv-fix-typo on branch f
 ```
 
 Work in the new `../cv-<name>` directory (build with `make page-container`). On your first push use
-`git push -u origin <name>` — the worktree branch starts with no upstream. Remove it when done with
-`make worktree-rm name=<name>` (drops the worktree and its per-worktree `node_modules` volume).
-Worktrees are the standard branching workflow — always branch off `origin/main`, never a stale local
-`main`.
+`git push -u origin <name>` — the worktree branch starts with no upstream. Worktrees are the standard
+branching workflow — always branch off `origin/main`, never a stale local `main`.
+
+**Cleanup is automatic.** Once a PR merges, the repo deletes its remote branch (squash-merge +
+delete-branch-on-merge), leaving the worktree and local branch behind. `make worktree` prunes merged
+worktrees before creating the next one, so they clear themselves in the normal loop. To prune on
+demand — or remove a specific one yourself — use:
+
+```sh
+make worktree-prune                        # remove all merged worktrees (branch + node_modules volume)
+bash scripts/worktree-prune.sh --dry-run   # preview what would be removed
+make worktree-rm name=<name>               # remove one by hand (worktree + its node_modules volume)
+```
+
+The prune is safe: it never touches the main worktree, the current worktree, the default branch, or
+any worktree with uncommitted or untracked changes. It removes a worktree only when `gh` reports a
+**merged PR** for its branch *and* the local tip is provably that merged work (its HEAD matches the
+merged PR's head commit, or is already in `main`) — so a branch with extra local commits beyond the
+PR is kept. Without `gh` it can't verify a merge and prunes nothing. Each pruned worktree's
+per-worktree `node_modules` volume is dropped too (like `make worktree-rm`); the shared npm cache is
+kept.
 
 ## Linking pull requests
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -23,9 +23,10 @@ Chromium no-op that just re-downloads if the pinned Playwright version changes).
 Container tooling, **put workspace-independent installs in the Dockerfile, not `postCreate`.**
 `node_modules` and the npm cache live in named volumes — a **per-worktree** `node_modules` volume (so
 worktrees stay isolated and the container never clobbers the host's `node_modules`) plus a shared npm
-cache — which also makes `npm ci` fast on macOS. Removing a worktree with `make worktree-rm` drops
-its `node_modules` volume too; the shared npm cache persists across removals (reclaim it with
-`docker volume rm cv-npm-cache` if it ever grows large).
+cache — which also makes `npm ci` fast on macOS. Removing a worktree with `make worktree-rm` (or
+`make worktree-prune`, which sweeps all merged worktrees) drops its `node_modules` volume too; the
+shared npm cache persists across removals (reclaim it with `docker volume rm cv-npm-cache` if it ever
+grows large).
 
 > Without a Dev Container you can build with just Node + npm (`npm ci`), but you'll also need a
 > Chromium for the PDF and Docker for `make lint` / `make build`. The container is the supported path.
@@ -38,6 +39,7 @@ Everything goes through the `Makefile` — run `make <target>`:
 | ---- | ------- | ----- |
 | New branch (isolated worktree) | `make worktree name=<b>` | fetches + branches off `origin/main` into `../cv-<b>` |
 | Remove a worktree | `make worktree-rm name=<b>` | removes `../cv-<b>` + its per-worktree `node_modules` volume |
+| Prune merged worktrees | `make worktree-prune` | removes every worktree whose PR merged (branch + `node_modules` volume); auto-runs before `make worktree` |
 | Preview (build + watch + serve) | `npm start` | serves `dist/` on port 8080 (needs host Node) |
 | Build in the container (HTML + PDF) | `make page-container` | **preferred** — builds inside the Dev Container; host stays clean |
 | Build on the host (HTML + PDF) | `make page` | needs host Node + Playwright Chromium |

--- a/scripts/worktree-prune.sh
+++ b/scripts/worktree-prune.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# worktree-prune.sh — remove sibling git worktrees whose PR has been merged, and
+# delete their local branch. Built for the `make worktree` workflow, where each
+# branch lives in its own `../cv-<name>` worktree; once its PR is squash-merged
+# and the remote branch auto-deleted, the worktree and local branch linger.
+#
+# Usage:
+#   scripts/worktree-prune.sh [--dry-run]
+#
+# Safe by design:
+#   - never touches the main worktree, the default branch, or the current worktree;
+#   - skips any worktree with uncommitted or untracked changes (never --force);
+#   - prunes only when `gh` reports a MERGED PR for the branch AND the local tip is
+#     provably that merged work — its HEAD equals the merged PR's head commit
+#     (squash merges) or is already contained in the default branch. A branch with
+#     local commits beyond the merged PR is kept, so unpushed work is never lost;
+#   - without `gh` it can't verify a merge, so it prunes nothing (and says so);
+#   - drops each pruned worktree's per-worktree node_modules Docker volume too
+#     (like `make worktree-rm`); the shared npm cache is kept;
+#   - always exits 0 — problems are warnings, never fatal — so it can safely run as
+#     a best-effort step in front of `make worktree`.
+
+set -uo pipefail
+
+DRY_RUN=0
+case "${1:-}" in
+  --dry-run|-n) DRY_RUN=1 ;;
+  '') ;;
+  *) echo "Usage: $0 [--dry-run]" >&2; exit 0 ;;
+esac
+
+# Must be inside a git repo, else nothing to do.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Refresh remote-tracking refs and drop refs for branches deleted upstream.
+git fetch --prune --quiet origin 2>/dev/null || true
+
+# Space-safe worktree paths: strip the "worktree " prefix rather than field-split.
+list_worktrees() { git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p'; }
+
+# The main worktree is the first entry; it and the current worktree are off-limits.
+main_wt="$(list_worktrees | head -n1)"
+current_wt="$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
+
+# Default branch: prefer origin/HEAD, then a local main/master, else "main".
+default_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+if [ -z "$default_branch" ]; then
+  if git show-ref --verify --quiet refs/heads/master && ! git show-ref --verify --quiet refs/heads/main; then
+    default_branch="master"
+  else
+    default_branch="main"
+  fi
+fi
+
+# Is `gh` usable (installed + authenticated)? It's the merge authority.
+have_gh=0
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  have_gh=1
+fi
+
+# merged_pr_heads <branch> — echo the head-commit SHA of each MERGED PR for the
+# branch (via gh). Empty when there are none or gh is unavailable.
+merged_pr_heads() {
+  [ "$have_gh" = 1 ] || return 0
+  gh pr list --head "$1" --state merged --json headRefOid --jq '.[].headRefOid' 2>/dev/null
+}
+
+# safe_to_prune <wt> <branch> — 0 when the worktree's work is provably merged and
+# nothing unique would be lost. Sets $PRUNE_REASON and returns non-zero otherwise.
+PRUNE_REASON=""
+safe_to_prune() {
+  local wt="$1" br="$2" wt_head heads
+  PRUNE_REASON=""
+  if [ "$have_gh" != 1 ]; then
+    PRUNE_REASON="gh unavailable — cannot verify a merged PR; install/auth gh or remove by hand"
+    return 1
+  fi
+  heads="$(merged_pr_heads "$br")"
+  if [ -z "$heads" ]; then
+    PRUNE_REASON="no merged PR"
+    return 1
+  fi
+  wt_head="$(git -C "$wt" rev-parse HEAD 2>/dev/null)" || { PRUNE_REASON="cannot resolve HEAD"; return 1; }
+  # Safe when the tip is exactly what was merged (squash), or already contained in
+  # the default branch (merge/rebase) — otherwise there are unmerged local commits.
+  if printf '%s\n' "$heads" | grep -qxF "$wt_head" \
+     || git -C "$wt" merge-base --is-ancestor HEAD "origin/$default_branch" 2>/dev/null; then
+    return 0
+  fi
+  PRUNE_REASON="merged, but local HEAD has commits beyond the merged PR — remove by hand if intended"
+  return 1
+}
+
+pruned=0 kept=0
+while IFS= read -r wt; do
+  [ -n "$wt" ] || continue
+  [ "$wt" = "$main_wt" ] && continue
+  [ "$wt" = "$current_wt" ] && continue
+
+  # Resolve the worktree's branch; skip detached HEADs (nothing safe to key on).
+  br="$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null)" || { echo "keep  $wt — detached HEAD"; kept=$((kept + 1)); continue; }
+  [ -n "$br" ] || { kept=$((kept + 1)); continue; }
+  [ "$br" = "$default_branch" ] && continue
+
+  # Never remove work in progress: any uncommitted or untracked change blocks it.
+  if [ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]; then
+    echo "keep  $wt ($br) — has uncommitted/untracked changes"
+    kept=$((kept + 1)); continue
+  fi
+
+  if ! safe_to_prune "$wt" "$br"; then
+    echo "keep  $wt ($br) — $PRUNE_REASON"
+    kept=$((kept + 1)); continue
+  fi
+
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "prune $wt ($br) — merged [dry-run]"
+    pruned=$((pruned + 1)); continue
+  fi
+
+  if git worktree remove "$wt" 2>/dev/null; then
+    git branch -D "$br" >/dev/null 2>&1 || true
+    # Drop the per-worktree node_modules Docker volume too (shared npm cache is
+    # kept), mirroring `make worktree-rm`. Best-effort: skipped if docker is
+    # absent or the volume is still in use by a running Dev Container.
+    if command -v docker >/dev/null 2>&1; then
+      docker volume rm "cv-node-modules-$(basename "$wt")" >/dev/null 2>&1 || true
+    fi
+    echo "prune $wt ($br) — merged"
+    pruned=$((pruned + 1))
+  else
+    echo "keep  $wt ($br) — 'git worktree remove' refused (locked or dirty)"
+    kept=$((kept + 1))
+  fi
+done < <(list_worktrees)
+
+if [ "$DRY_RUN" = 1 ]; then
+  echo "worktree-prune: would remove ${pruned}, keep ${kept} (dry-run)"
+else
+  echo "worktree-prune: removed ${pruned}, kept ${kept}"
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #83. Merged worktrees (and their local branches) piled up because the repo is **squash-merge + delete-branch-on-merge**: after a PR merges, its remote branch is deleted but the `../cv-<name>` worktree and local branch linger. This adds automated cleanup.

## Changes

- **`scripts/worktree-prune.sh`** — removes sibling worktrees whose PR has merged and deletes their local branch. `--dry-run` previews.
- **`make worktree-prune`** — runs it on demand.
- **`make worktree`** — runs the prune best-effort (`|| true`) before creating the next worktree, so cleanup happens in the normal loop with no extra step.
- Docs: `AGENTS.md` + `docs/contributing.md`.

## Safety (a merged branch gets deleted, so the bar is high)

- Never touches the **main** worktree, the **current** worktree, or the **default branch**; skips any worktree with **uncommitted/untracked** changes (no `--force`).
- Prunes only when `gh` reports a **merged PR** for the branch **and** the local tip is provably that merged work — HEAD equals the merged PR's head commit (squash merges) or is already contained in `main`. **A branch with commits beyond the merged PR is kept**, so unpushed work is never lost.
- Without `gh` it can't verify a merge and **prunes nothing**.
- Always exits 0 so a hiccup never blocks `make worktree`.

## Verification (scripted, real PR data)

- Merged worktree whose HEAD == merged PR head → **pruned**; then a commit added beyond that head → **kept** ("commits beyond the merged PR").
- Fresh empty branch (HEAD == `origin/main`, no PR) → **kept** ("no merged PR") — no false prune of a just-created worktree.
- Dirty worktree, main, current, default branch → **kept/skipped**; non-repo cwd → no-op; `gh` masked → prunes nothing.
- Live: correctly pruned the three worktrees whose PRs (#80/#81/#82) had merged, keeping open/dirty ones.
- `shellcheck` clean, `bash -n` OK, `markdownlint` clean.

## Self-review

Reviewed independently via adversarial reviewer agents (the worktree diff isn't visible to `/code-review` from the main checkout). Two HIGH findings fixed before this PR: (1) inferring merge from branch name could delete commits added after the merge — now gated on the merged PR's head SHA matching the local tip; (2) the original "gone upstream branch" fallback could fire on never-merged branches — removed, so no-`gh` prunes nothing. Also hardened: space-safe worktree-path parsing and `origin/HEAD`-based default-branch detection.

Scope note: sweeping the pre-existing dangling *local branches* that have no worktree is intentionally out of scope (per the agreed plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)