### PR TITLE
Mount per-worktree node_modules + npm-cache volumes in the Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,10 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
+  "mounts": [
+    "source=cv-node-modules-${localWorkspaceFolderBasename},target=${containerWorkspaceFolder}/node_modules,type=volume",
+    "source=cv-npm-cache,target=/root/.npm,type=volume"
+  ],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/python:1": {

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += -s
 
-.PHONY: dev clean page page-container worktree lint lint-fast build dev-build \
+.PHONY: dev clean page page-container worktree worktree-rm lint lint-fast build dev-build \
 	logs-app-builder logs-webserver logs-certbot \
 	remove-app-builder remove-certbot \
 	certificates certificates-dry-run \
@@ -39,7 +39,17 @@ worktree:
 	git fetch origin
 	git worktree add "../cv-$(subst /,-,$(name))" -b "$(name)" --no-track origin/main
 	echo "Worktree: ../cv-$(subst /,-,$(name))  (branch '$(name)' off origin/main)"
-	echo "Next: cd ../cv-$(subst /,-,$(name)) && make page-container   (remove later: git worktree remove ../cv-$(subst /,-,$(name)))"
+	echo "Next: cd ../cv-$(subst /,-,$(name)) && make page-container   (remove later: make worktree-rm name=$(name))"
+
+# Remove a worktree created by `make worktree` plus its per-worktree node_modules volume (the shared
+# npm cache is kept). Stop the worktree's Dev Container first, else the volume removal is skipped.
+# Usage: make worktree-rm name=<branch>
+# Dependencies: git, docker
+worktree-rm:
+	test -n "$(name)" || { echo "Usage: make worktree-rm name=<branch>  (e.g. make worktree-rm name=fix/typo)"; exit 1; }
+	git worktree remove "../cv-$(subst /,-,$(name))"
+	docker volume rm "cv-node-modules-cv-$(subst /,-,$(name))" 2>/dev/null && echo "removed node_modules volume" || echo "(node_modules volume not found or in use — stop its Dev Container, then: docker volume rm cv-node-modules-cv-$(subst /,-,$(name)))"
+	echo "Removed worktree ../cv-$(subst /,-,$(name))  (shared npm cache kept)"
 
 lint:
 	docker run --rm \

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -82,8 +82,9 @@ make worktree name=fix/typo   # fetches, then creates ../cv-fix-typo on branch f
 
 Work in the new `../cv-<name>` directory (build with `make page-container`). On your first push use
 `git push -u origin <name>` — the worktree branch starts with no upstream. Remove it when done with
-`git worktree remove ../cv-<name>`. Worktrees are the standard branching workflow — always branch off
-`origin/main`, never a stale local `main`.
+`make worktree-rm name=<name>` (drops the worktree and its per-worktree `node_modules` volume).
+Worktrees are the standard branching workflow — always branch off `origin/main`, never a stale local
+`main`.
 
 ## Linking pull requests
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -21,6 +21,11 @@ spec-kit `specify` CLI, and the Claude Code CLI — so they persist across conta
 cheap to spin up per git worktree. `postCreate` runs only workspace-specific steps (`npm ci`, plus a
 Chromium no-op that just re-downloads if the pinned Playwright version changes). When adding Dev
 Container tooling, **put workspace-independent installs in the Dockerfile, not `postCreate`.**
+`node_modules` and the npm cache live in named volumes — a **per-worktree** `node_modules` volume (so
+worktrees stay isolated and the container never clobbers the host's `node_modules`) plus a shared npm
+cache — which also makes `npm ci` fast on macOS. Removing a worktree with `make worktree-rm` drops
+its `node_modules` volume too; the shared npm cache persists across removals (reclaim it with
+`docker volume rm cv-npm-cache` if it ever grows large).
 
 > Without a Dev Container you can build with just Node + npm (`npm ci`), but you'll also need a
 > Chromium for the PDF and Docker for `make lint` / `make build`. The container is the supported path.
@@ -32,6 +37,7 @@ Everything goes through the `Makefile` — run `make <target>`:
 | Task | Command | Notes |
 | ---- | ------- | ----- |
 | New branch (isolated worktree) | `make worktree name=<b>` | fetches + branches off `origin/main` into `../cv-<b>` |
+| Remove a worktree | `make worktree-rm name=<b>` | removes `../cv-<b>` + its per-worktree `node_modules` volume |
 | Preview (build + watch + serve) | `npm start` | serves `dist/` on port 8080 (needs host Node) |
 | Build in the container (HTML + PDF) | `make page-container` | **preferred** — builds inside the Dev Container; host stays clean |
 | Build on the host (HTML + PDF) | `make page` | needs host Node + Playwright Chromium |


### PR DESCRIPTION
## Summary

Mount named Docker volumes in the Dev Container so `node_modules` no longer bind-mounts over the
host worktree folder, and npm stays fast on macOS:

- **`.devcontainer/devcontainer.json`** — a **per-worktree** `node_modules` volume
  (`cv-node-modules-${localWorkspaceFolderBasename}`, so each worktree is isolated and the container
  never clobbers the host's `node_modules`) plus a **shared** `cv-npm-cache` volume for warm installs.
- **`Makefile`** — `make worktree-rm name=<b>` removes a worktree *and* its per-worktree
  `node_modules` volume (shared npm cache kept); the `make worktree` hint now points at it.
- **`docs/local-development.md` + `docs/contributing.md`** — document the volumes and the
  `make worktree-rm` teardown.

## Why

`make worktree` gives each branch its own checkout, but without this every worktree container
bind-mounted `node_modules` onto the host folder — installs in the container clobbered the host and
vice-versa, and macOS bind-mount `npm ci` is slow. Per-worktree named volumes isolate dependencies
and keep `npm ci` fast.

## Verification

- A `docker run` simulating the mount showed `npm ci` populates `node_modules` **in the volume**
  (542 entries) while the host worktree dir's `node_modules` stayed empty — no clobber in either
  direction.
- `make worktree-rm name=voltest` removed the worktree **and** its `cv-node-modules-cv-voltest`
  volume; the shared `cv-npm-cache` was kept.
- `make lint-fast` (JS `standard` + markdownlint) clean.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)