### PR TITLE
Pin Dev Container base image by digest + features by version (#77)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,15 @@
 # Bakes the heavy, workspace-INDEPENDENT tooling into the image so it persists across container
 # rebuilds and is cheap per git worktree. Workspace-specific dependencies (node_modules) stay in
 # postCreate. See docs/local-development.md.
-FROM mcr.microsoft.com/devcontainers/javascript-node:22-bookworm
+#
+# Base image pinned by digest for reproducibility (constitution Principle V — "pin what determines
+# output"). The tag is kept for readability; the digest is what actually pins. This is the multi-arch
+# *index* digest, so it resolves on both amd64 (CI) and arm64 (Apple Silicon). To refresh on an
+# intentional base bump, re-resolve the tag's index digest and update the digest below:
+#   curl -sSI -H 'Accept: application/vnd.oci.image.index.v1+json' \
+#     https://mcr.microsoft.com/v2/devcontainers/javascript-node/manifests/22-bookworm \
+#     | grep -i docker-content-digest
+FROM mcr.microsoft.com/devcontainers/javascript-node:22-bookworm@sha256:92e97da1df8f4135188053b3a5e22e3ef316ecaf2a0d33b8831e1dec5cdaa77f
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,11 +9,11 @@
     "source=cv-npm-cache,target=/root/.npm,type=volume"
   ],
   "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
-    "ghcr.io/devcontainers/features/python:1": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1.10.0": {},
+    "ghcr.io/devcontainers/features/python:1.8.0": {
       "version": "3.12"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1.1.0": {}
   },
   "forwardPorts": [
     8080

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -27,6 +27,27 @@ cache — which also makes `npm ci` fast on macOS. Removing a worktree with `mak
 its `node_modules` volume too; the shared npm cache persists across removals (reclaim it with
 `docker volume rm cv-npm-cache` if it ever grows large).
 
+**Pinning (reproducibility).** Per constitution Principle V ("pin what determines output"), the Dev
+Container inputs are pinned: the `.devcontainer/Dockerfile` base image is pinned by its multi-arch
+**index digest** (`…:22-bookworm@sha256:…`, resolving on both amd64/CI and arm64/Apple Silicon), and
+the `devcontainer.json` features are pinned to exact versions (e.g. `python:1.8.0` — the *feature*
+version, independent of the Python it installs via `"version": "3.12"`) rather than the moving `:1`
+major tag. This freezes those inputs — including the features' own patch/security updates — until
+someone bumps them, so refresh **deliberately**, not incidentally:
+
+- **Base image** — re-resolve the tag's index digest and update it in the Dockerfile (the exact
+  `curl` command is in a comment above the `FROM`).
+- **Features** — bump to a newer published version from
+  [`devcontainers/features`](https://github.com/devcontainers/features) (e.g.
+  `ghcr.io/devcontainers/features/python:<x.y.z>`).
+
+After either bump, rebuild (`devcontainer build --workspace-folder .` or `make dev`) and confirm the
+image builds and hadolint stays green (via `make lint`).
+
+Not everything is pinned: the global CLIs baked into the Dockerfile (`uv`, the spec-kit `specify`
+CLI, `claude-code`) and the `gh` binary the `github-cli` feature installs still fetch their latest at
+build time — only the base image and the feature *packages* are pinned.
+
 > Without a Dev Container you can build with just Node + npm (`npm ci`), but you'll also need a
 > Chromium for the PDF and Docker for `make lint` / `make build`. The container is the supported path.
 


### PR DESCRIPTION
## Summary

Closes #77. The Dev Container base image used a moving tag (`mcr.microsoft.com/devcontainers/javascript-node:22-bookworm`) and its features used the moving `:1` major tag, so the environment could change under us — undermining reproducibility (constitution **Principle V**, "pin what determines output").

## Changes

- **`.devcontainer/Dockerfile`** — pin `FROM` by the base image's **multi-arch _index_ digest** (`…:22-bookworm@sha256:92e97da1…`). The tag is kept for readability; the digest is what pins. Using the *index* (not a per-arch) digest is deliberate so it resolves on **both amd64 (CI/Linux) and arm64 (Apple Silicon)**. A comment above `FROM` carries the exact `curl` to re-resolve the digest on an intentional bump.
- **`.devcontainer/devcontainer.json`** — pin the three features to exact versions: `docker-outside-of-docker:1.10.0`, `python:1.8.0`, `github-cli:1.1.0` (the versions `:1` currently resolves to → **no behavior change**). Python's installed version stays `3.12` (that's the feature's option, independent of the feature version).
- **`docs/local-development.md`** — document how/when to refresh (base digest + feature versions), and state honestly what is **not** pinned: `uv`, the spec-kit `specify` CLI, `claude-code`, and the `gh` binary still install their latest at build time — only the base image and feature *packages* are pinned.

## Verification

- Pinned digest **equals the live `22-bookworm` tag's index digest**, content-type `application/vnd.oci.image.index.v1+json` (multi-arch). `docker pull` by digest succeeds.
- **`devcontainer build --workspace-folder .` succeeds** — features resolve at 1.10.0 / 1.8.0 / 1.1.0 and `FROM` uses the pinned digest (full build, exit 0).
- `hadolint` exits 0 (tag+digest satisfies DL3006; no `:latest` so DL3007 is fine); `devcontainer.json` is valid strict JSON; `markdownlint` clean.

## Self-review

Reviewed independently via an adversarial reviewer agent. Acted on its findings: docs now disclose the unpinned build-time installs (avoids over-claiming "reproducible"), note that pinning freezes the features' own patch/security updates until a manual bump, clarify the feature-version vs installed-Python-version distinction, and point the refresh check at `make lint` (the hadolint gate). Confirmed no other reference to this base image needs syncing (the *build* image `node:22-bookworm-slim` is unrelated and untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)