### PR TITLE
Prebuild the Dev Container image in CI and pull it (GHCR)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "name": "cv",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": ".."
+    "context": "..",
+    "cacheFrom": "ghcr.io/brunogbv/cv-devcontainer"
   },
   "mounts": [
     "source=cv-node-modules-${localWorkspaceFolderBasename},target=${containerWorkspaceFolder}/node_modules,type=volume",

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,61 @@
+---
+name: Dev Container
+
+# Prebuild the Dev Container image and publish it to GHCR so `devcontainer up`
+# (on any machine and in each `make worktree`) pulls cached layers instead of
+# building the image from scratch. See docs/ci-cd.md.
+#
+# Runs when the image's inputs change: the .devcontainer/ dir, the manifests the
+# Dockerfile bakes in (package.json / package-lock.json drive the Playwright
+# layer), or this workflow. Pull requests build + smoke-test without publishing;
+# pushes to main publish.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .devcontainer/**
+      - package.json
+      - package-lock.json
+      - .github/workflows/devcontainer.yml
+  pull_request:
+    paths:
+      - .devcontainer/**
+      - package.json
+      - package-lock.json
+      - .github/workflows/devcontainer.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build, smoke-test, and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # devcontainers/ci builds .devcontainer (Dockerfile + features), runs the
+      # container lifecycle (postCreate: npm ci + playwright install), then runs
+      # `runCmd` inside it. `make page` is the smoke test: it proves the image
+      # renders the HTML page and the PDF. `push: filter` publishes only on
+      # pushes to the default branch — pull requests build + smoke-test but do
+      # not publish. `cacheFrom` reuses the last published image's layers so
+      # unchanged builds are near-instant.
+      - name: Build, smoke-test, and publish the Dev Container image
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository_owner }}/cv-devcontainer
+          cacheFrom: ghcr.io/${{ github.repository_owner }}/cv-devcontainer
+          push: filter
+          runCmd: make page

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@
 Personal CV / résumé site for Bruno Valério, hosted at <https://valerio.dev>. It's a small
 Node.js static-site generator: CV content lives in a JavaScript data file, is rendered through
 Handlebars into a single HTML page, and a matching PDF is produced with Playwright. The output is
-served as static files behind nginx (Docker Compose) with Let's Encrypt TLS via certbot. CI is
-lint-only (Super-Linter); deployment is manual.
+served as static files behind nginx (Docker Compose) with Let's Encrypt TLS via certbot. CI lints
+every change (Super-Linter) and prebuilds the Dev Container image (published to GHCR); site
+deployment is manual.
 
 ## Architecture
 
@@ -59,13 +60,17 @@ Deploy is **manual**:
 - There are **no** unit or integration tests in this repo.
 - **Validate locally before pushing.** During iteration use `make lint-fast` (fast native JS +
   Markdown lint) and/or the Dev Container's editor extensions; before opening/updating a PR run
-  `make lint` — it runs the *same* Super-Linter image CI uses (linting is the only CI gate), so you
-  catch failures locally instead of waiting on the push-and-wait PR cycle. See
-  [`docs/ci-cd.md`](docs/ci-cd.md) for details and caveats.
+  `make lint` — it runs the *same* Super-Linter image CI uses (linting is the CI gate for code and
+  content changes), so you catch failures locally instead of waiting on the push-and-wait PR cycle.
+  See [`docs/ci-cd.md`](docs/ci-cd.md) for details and caveats.
 - Linting via Super-Linter runs on every push/PR (`.github/workflows/superlinter.yml`); `make lint`
   reproduces it locally.
 - The Vercel deploy-preview check runs server-side and is **not** reproduced by `make lint`; it can
   only be validated after pushing.
+- Changes under `.devcontainer/**` (or `package.json` / `package-lock.json`) also trigger the **Dev
+  Container** prebuild workflow (`.github/workflows/devcontainer.yml`): it builds the image and runs
+  `make page` as a smoke test on the PR, then publishes it to GHCR on merge to `main`. Not
+  reproduced by `make lint`. See [`docs/ci-cd.md`](docs/ci-cd.md).
 - Enabled linters (`config/lint/super-linter.env`): JavaScript (`standard` style), CSS
   (stylelint + `stylelint-config-standard`), HTML, Dockerfile (hadolint), JSON, YAML, Markdown,
   XML, and GitHub Actions. `src/templates/*` is excluded from linting.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,11 +1,14 @@
 # CI/CD
 
-CI is automated and lint-only. Deployment (CD) is **manual** — there is no pipeline that ships the
-site; a human runs `make` targets on the host that serves [valerio.dev](https://valerio.dev).
+CI is automated: it lints every change and prebuilds the Dev Container image. Deployment (CD) of the
+site is **manual** — there is no pipeline that ships the site; a human runs `make` targets on the
+host that serves [valerio.dev](https://valerio.dev).
 
 ## Continuous Integration — GitHub Actions
 
-One workflow: **`.github/workflows/superlinter.yml`** (name: `Lint`).
+Two workflows: **`.github/workflows/superlinter.yml`** (name: `Lint`) lints every change, and
+**`.github/workflows/devcontainer.yml`** (name: `Dev Container`) prebuilds the Dev Container image
+(see [Dev Container image prebuild](#dev-container-image-prebuild)). The lint workflow:
 
 - **Triggers:** every `push` and every `pull_request`.
 - **Runner:** `ubuntu-latest`.
@@ -16,7 +19,9 @@ One workflow: **`.github/workflows/superlinter.yml`** (name: `Lint`).
      (`permissions: statuses: write`, using the default `GITHUB_TOKEN`).
 - A Super-Linter status badge is shown at the top of the root [`README.md`](../README.md).
 
-There are **no automated tests** and **no build/deploy** in CI — linting is the only gate.
+There are **no automated tests** for the site and **no site build/deploy** in CI — linting is the
+only gate on site changes. (The Dev Container workflow below builds and smoke-tests the *dev
+environment* image; it does not build or deploy the site itself.)
 
 ### Linter configuration
 
@@ -59,6 +64,34 @@ Caveats:
   against `main`. Local is broader, not narrower.
 - **Vercel:** the deploy-preview check runs on Vercel's side and is **not** covered by `make lint`;
   it can only be validated after pushing.
+
+### Dev Container image prebuild
+
+`.github/workflows/devcontainer.yml` (name: `Dev Container`) prebuilds the Dev Container image and
+publishes it to the GitHub Container Registry (GHCR), so `devcontainer up` — on any machine and in
+each `make worktree` — pulls cached layers instead of building the image from scratch.
+
+- **Triggers:** `push` to `main` and `pull_request`, both filtered to the paths that determine the
+  image (`.devcontainer/**`, `package.json`, `package-lock.json`, and the workflow file); plus
+  manual `workflow_dispatch`.
+- **What it does:** logs in to GHCR (`docker/login-action`, `packages: write` + `GITHUB_TOKEN`),
+  then `devcontainers/ci@v0.3` builds the image (Dockerfile + features), runs the container
+  lifecycle (`postCreate`: `npm ci` + `playwright install`), and runs **`make page`** inside it as a
+  smoke test that the image renders the HTML page and the PDF.
+- **Publish vs. build-only:** `push: filter` publishes the image
+  (`ghcr.io/brunogbv/cv-devcontainer:latest`) **only on pushes to `main`**. Pull requests and manual
+  `workflow_dispatch` runs build and smoke-test the image but do **not** publish — so a broken
+  Dockerfile is caught at PR time.
+- **Consumption + fallback:** `devcontainer.json`'s `build.cacheFrom` points at the same GHCR image,
+  so `devcontainer up` reuses the published layers (near-instant when unchanged). If the registry is
+  unreachable or the image is missing, the build simply falls back to a normal local build — the
+  prebuild is an optimization, never a hard dependency.
+
+**One-time owner step (manual):** for anonymous pulls to work — so contributors get the cache
+without a `docker login` — the GHCR package must be **public**. After the first publish from `main`,
+set the `cv-devcontainer` package to Public once (GitHub → your Packages → `cv-devcontainer` →
+Package settings → Change visibility → Public). Until then, only authenticated pulls hit the cache
+and everyone else falls back to a local build (which still works, just slower).
 
 ## Continuous Deployment — manual, Docker-based
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -26,7 +26,9 @@ worktrees stay isolated and the container never clobbers the host's `node_module
 cache — which also makes `npm ci` fast on macOS. Removing a worktree with `make worktree-rm` (or
 `make worktree-prune`, which sweeps all merged worktrees) drops its `node_modules` volume too; the
 shared npm cache persists across removals (reclaim it with `docker volume rm cv-npm-cache` if it ever
-grows large).
+grows large). The image is also **prebuilt in CI and published to GHCR**, so `devcontainer up` pulls
+those layers via `build.cacheFrom` (near-instant) and falls back to a local build if the registry is
+unavailable — see [ci-cd.md](ci-cd.md#dev-container-image-prebuild).
 
 **Pinning (reproducibility).** Per constitution Principle V ("pin what determines output"), the Dev
 Container inputs are pinned: the `.devcontainer/Dockerfile` base image is pinned by its multi-arch


### PR DESCRIPTION
## Summary

Prebuild the Dev Container image in CI and publish it to GHCR, then have `devcontainer up` consume
it as a build cache — so setup on any machine and in each `make worktree` pulls prebuilt layers
instead of rebuilding the image from scratch. Builds on #69 (image-baking) and #77 (digest-pinned
base + version-pinned features).

## Changes

- **`.github/workflows/devcontainer.yml`** (new, name: `Dev Container`) — triggers on push to `main`
  and `pull_request` (both paths-filtered to `.devcontainer/**`, `package.json`, `package-lock.json`,
  and the workflow itself) plus manual `workflow_dispatch`. Logs in to GHCR
  (`docker/login-action`, `packages: write` + `GITHUB_TOKEN`), then `devcontainers/ci@v0.3` builds
  the image (Dockerfile + features), runs the container lifecycle (`postCreate`: `npm ci` +
  `playwright install`), and runs **`make page`** inside it as a smoke test that the HTML page and
  PDF render. `push: filter` publishes only on pushes to `main`; PRs and manual runs build +
  smoke-test **without** publishing (so a broken Dockerfile is caught at PR time).
- **`.devcontainer/devcontainer.json`** — `build.cacheFrom` → `ghcr.io/brunogbv/cv-devcontainer`, so
  `devcontainer up` reuses published layers (near-instant when unchanged) and **falls back to a
  normal local build** if the registry is unreachable or the image is missing (the prebuild is an
  optimization, never a hard dependency).
- **docs** — `docs/ci-cd.md` (new *Dev Container image prebuild* section + intro/overview),
  `docs/local-development.md`, and `AGENTS.md`.

## Owner action (one-time, after merge)

This PR modifies `.devcontainer/**` and adds the workflow, so **merging to `main` self-triggers the
first publish**. After that first publish, set the `cv-devcontainer` GHCR package to **Public** once
(GitHub → your Packages → `cv-devcontainer` → Package settings → Change visibility) so contributors
get anonymous cache pulls. Until then, pulls fall back to a local build (still works, just slower).

## Verification

- `actionlint` clean; Super-Linter's `yamllint` (its exact config) reports **0 warnings/errors**;
  `devcontainer.json` valid JSON; `markdownlint` clean.
- Confirmed `make` is present in the pinned base image (`/usr/bin/make`, GNU Make 4.3), so
  `runCmd: make page` runs.
- Self-review (independent adversarial pass): three fork-PR findings surfaced; two were refuted
  (`push: filter` never publishes on PRs, and `github.repository_owner` = `brunogbv` in all runs, so
  no namespace mismatch — hardcoding the canonical public image is what gives forks a cache hit); the
  third (a doc-precision nit on `workflow_dispatch`) was addressed.
- The end-to-end pull path is validated after the first publish + the one-time package-public step
  (chicken-and-egg, like the Vercel preview).

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)