### PR TITLE
Fix `make lint` on Apple Silicon + git worktrees (#91)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ Deploy is **manual**:
   content changes), so you catch failures locally instead of waiting on the push-and-wait PR cycle.
   See [`docs/ci-cd.md`](docs/ci-cd.md) for details and caveats.
 - Linting via Super-Linter runs on every push/PR (`.github/workflows/superlinter.yml`); `make lint`
-  reproduces it locally.
+  reproduces it locally — including on Apple Silicon (it runs the amd64 image emulated) and from a
+  `make worktree` sibling. On arm64 it skips the GitHub Actions validator (actionlint segfaults under
+  emulation); run `make lint-actions` (native `actionlint`) to check workflow files there.
 - The Vercel deploy-preview check runs server-side and is **not** reproduced by `make lint`; it can
   only be validated after pushing.
 - Changes under `.devcontainer/**` (or `package.json` / `package-lock.json`) also trigger the **Dev

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += -s
 
-.PHONY: dev clean page page-container worktree worktree-rm worktree-prune lint lint-fast build dev-build \
+.PHONY: dev clean page page-container worktree worktree-rm worktree-prune lint lint-actions lint-fast build dev-build \
 	logs-app-builder logs-webserver logs-certbot \
 	remove-app-builder remove-certbot \
 	certificates certificates-dry-run \
@@ -61,13 +61,52 @@ worktree-rm:
 worktree-prune:
 	bash scripts/worktree-prune.sh
 
+# Full CI-parity lint via the same Super-Linter image CI uses.
+#   - Pinned to CI's version (v6.7.0), not `latest`, so a local pass == CI.
+#   - `--platform linux/amd64`: Super-Linter ships no arm64 image, so this runs
+#     emulated on Apple Silicon (a no-op on amd64 CI/Intel hosts).
+#   - Git-dir mount: from a `make worktree` sibling the tree's `.git` is a *file*
+#     pointing at the main checkout's `.git` by absolute path, so we also bind-mount
+#     that path — otherwise Super-Linter's git can't resolve `main`/`origin/main`. In
+#     a plain checkout it's a harmless no-op (the `.git` dir is already in the tree).
+#     `safe.directory=*` stops git's "dubious ownership" error on the bind mounts.
+#   - `SHELL=/bin/bash`: Super-Linter builds its file list with GNU `parallel`, which
+#     runs workers via `$SHELL`; unset, it falls back to `/bin/sh` and can't see the
+#     bash functions Super-Linter exports (`BuildFileArrays: not found`). Setting it to
+#     bash fixes the file-list step when run locally via `docker run`.
+#   - On arm64 the GITHUB_ACTIONS validator (actionlint) crashes with a SIGSEGV under
+#     QEMU emulation, so it's skipped here. Super-Linter forbids mixing include (`=true`)
+#     and exclude (`=false`) flags, so rather than set it `=false` we lint with a copy of
+#     the env-file that drops the `VALIDATE_GITHUB_ACTIONS` line; workflows are checked
+#     natively (no emulation) by `make lint-actions` instead.
+LINT_IMAGE := ghcr.io/super-linter/super-linter:v6.7.0
+LINT_GIT_COMMON_DIR := $(shell git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "$(CURDIR)/.git")
+LINT_SKIP_ACTIONS := $(if $(filter arm64 aarch64,$(shell uname -m)),1,)
 lint:
+	envfile=config/lint/super-linter.env; \
+	if [ -n "$(LINT_SKIP_ACTIONS)" ]; then \
+		envfile="$$(mktemp)"; trap 'rm -f "$$envfile"' EXIT; \
+		grep -v '^VALIDATE_GITHUB_ACTIONS=' config/lint/super-linter.env > "$$envfile"; \
+		echo "note: GitHub Actions linting is skipped under emulation on this arch — run 'make lint-actions' to check workflows"; \
+	fi; \
 	docker run --rm \
+		--platform linux/amd64 \
 		-e LOG_LEVEL=INFO \
 		-e RUN_LOCAL=true \
-		--env-file "config/lint/super-linter.env" \
-		-v $(shell pwd):/tmp/lint \
-		ghcr.io/super-linter/super-linter:latest
+		-e SHELL=/bin/bash \
+		-e GIT_CONFIG_COUNT=1 \
+		-e GIT_CONFIG_KEY_0=safe.directory \
+		-e GIT_CONFIG_VALUE_0='*' \
+		--env-file "$$envfile" \
+		-v "$(CURDIR):/tmp/lint" \
+		-v "$(LINT_GIT_COMMON_DIR):$(LINT_GIT_COMMON_DIR):ro" \
+		$(LINT_IMAGE)
+
+# Lint GitHub Actions workflows with actionlint (native — works on arm64, where the
+# emulated Super-Linter above skips its GITHUB_ACTIONS validator). Pinned to the same
+# actionlint version Super-Linter v6.7.0 bundles, so this matches the CI check.
+lint-actions:
+	docker run --rm -v "$(CURDIR):/repo" -w /repo rhysd/actionlint:1.7.1 -color
 
 # Fast local lint (JS via standard, Markdown via markdownlint) — a quick subset of
 # `make lint` for the common edit types. `make lint` (Super-Linter) stays the

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -51,8 +51,11 @@ updating a PR to get feedback in one pass instead of the push-and-wait cycle:
 make lint
 ```
 
-This runs the **same** Super-Linter image in Docker with `RUN_LOCAL=true`, using
-`config/lint/super-linter.env`, so a local pass closely matches the CI result.
+This runs the **same** Super-Linter image CI pins (`v6.7.0`) in Docker with `RUN_LOCAL=true`, using
+`config/lint/super-linter.env`, so a local pass closely matches the CI result. It works on Apple
+Silicon (the image is amd64-only, so the target runs it via `--platform linux/amd64`) and from a
+`make worktree` sibling (the target also bind-mounts the shared git dir — a worktree's `.git` is a
+file pointing at the main checkout — so Super-Linter can resolve `main`).
 
 For a quicker inner-loop check, `make lint-fast` runs just the JavaScript (`standard`) and Markdown
 (`markdownlint`) linters natively — no Docker, no full image — calibrated to approximate CI's
@@ -62,8 +65,12 @@ CI-parity check.
 
 Caveats:
 
-- **Image version:** `make lint` pulls `super-linter:latest`, while CI pins `v6.7.0`
-  (`.github/workflows/superlinter.yml`). Results can drift slightly between versions.
+- **Apple Silicon:** Super-Linter ships no arm64 image, so `make lint` runs it under emulation
+  (`--platform linux/amd64`) — correct, but slower than native. Under that emulation the
+  `GITHUB_ACTIONS` validator (actionlint) crashes with a SIGSEGV, so `make lint` **skips it on
+  arm64** (and says so); check workflows with **`make lint-actions`**, which runs actionlint natively
+  (pinned to the version Super-Linter bundles). On amd64 (CI/Intel) nothing is skipped. `make
+  lint-fast` stays the quick inner-loop check.
 - **Scope:** locally, Super-Linter lints the whole workspace; in CI it lints only files changed
   against `main`. Local is broader, not narrower.
 - **Vercel:** the deploy-preview check runs on Vercel's side and is **not** covered by `make lint`;


### PR DESCRIPTION
## Summary

Closes #91. `make lint` (the CI-parity Super-Linter check) was broken on Apple Silicon for two independent reasons, so "validate locally before pushing" failed exactly where it was needed. Both fixed, plus two issues that surfaced while fixing them.

## Changes (`Makefile` `lint` target)

- **arm64:** add `--platform linux/amd64` — Super-Linter ships no arm64 image (was an immediate *"no image for arm64"* error); runs emulated locally, a no-op on amd64 CI/Intel. Also **pin `v6.7.0`** (was `latest`) so local matches CI.
- **worktrees:** bind-mount the git **common dir** at its own absolute path. A `make worktree` sibling's `.git` is a *file* pointing at the main checkout's `.git`, so the container's git couldn't resolve `main`/`origin/main` (*"Neither main nor origin/main exist"*). Harmless no-op in a plain checkout.
- **file-list step:** `-e SHELL=/bin/bash` — Super-Linter builds its file list with GNU `parallel`, which runs workers via `$SHELL`; unset it fell back to `/bin/sh` and couldn't see the exported bash functions (`BuildFileArrays: not found`).
- **git ownership:** `safe.directory=*` to avoid git's "dubious ownership" error on the bind mounts.

## GitHub Actions validator on arm64

Under emulation, the `GITHUB_ACTIONS` validator (**actionlint**) crashes with a SIGSEGV. Since Super-Linter forbids mixing `VALIDATE_*=true` with any `=false`, `make lint` on arm64 lints with a **temp copy of the env-file that drops the `VALIDATE_GITHUB_ACTIONS` line** (and prints a note). New **`make lint-actions`** runs actionlint **natively** (pinned `rhysd/actionlint:1.7.1`, the version Super-Linter bundles) to cover workflows on arm64. On amd64 (CI/Intel) nothing is skipped.

## Verification (on Apple Silicon, from a worktree — the hardest case)

- `make lint` → **exit 0**; all validators pass (BASH, CSS, Dockerfile, JS, JSON, Markdown, YAML); `GITHUB_ACTIONS` cleanly skipped with the note; git resolved `main` via the mounted common dir.
- `make lint-actions` → **exit 0**, clean, native (no emulation).
- Docs markdownlint clean.

## Docs

`AGENTS.md` (Testing Instructions) and `docs/ci-cd.md` (Validate-locally + caveats) updated: v6.7.0 pin, `--platform` emulation, worktree git-dir mount, the arm64 actions-skip, and the `make lint-actions` companion.

## Note on the switch we considered

Full single-command parity would need Podman's `applehv`+Rosetta backend, but that's a disruptive provider migration (new VM, re-pulled images) — and native `make lint-actions` already covers workflows on arm64, so we deliberately did **not** go that route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)