### PR TITLE
Pin uv + spec-kit in the Dev Container; keep claude-code/gh latest (#88)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,12 +20,17 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3002
 USER root
 
-# uv + the spec-kit `specify` CLI (workspace-independent). uv's standalone installer needs no Python.
-RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh \
+# uv + the spec-kit `specify` CLI (workspace-independent), both version-pinned for reproducibility
+# (constitution Principle V). To bump: change the uv version in the installer URL
+# (https://astral.sh/uv/<version>/install.sh) and the spec-kit tag (@vX.Y.Z from
+# https://github.com/github/spec-kit/releases). uv's standalone installer needs no Python.
+RUN curl -LsSf https://astral.sh/uv/0.11.26/install.sh | UV_INSTALL_DIR=/usr/local/bin sh \
   && UV_TOOL_BIN_DIR=/usr/local/bin uv tool install \
-    --from git+https://github.com/github/spec-kit.git specify-cli
+    --from git+https://github.com/github/spec-kit.git@v0.12.4 specify-cli
 
-# Claude Code CLI (workspace-independent global).
+# Claude Code CLI (workspace-independent global). Intentionally NOT pinned — it's agent tooling we
+# want fresh, and (like the `gh` CLI from the github-cli feature) it doesn't affect the CV build
+# output, so it's outside Principle V's "pin what determines output". See docs/local-development.md.
 # hadolint ignore=DL3016
 RUN npm install -g @anthropic-ai/claude-code
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -43,13 +43,16 @@ someone bumps them, so refresh **deliberately**, not incidentally:
 - **Features** — bump to a newer published version from
   [`devcontainers/features`](https://github.com/devcontainers/features) (e.g.
   `ghcr.io/devcontainers/features/python:<x.y.z>`).
+- **Baked CLIs** — `uv` and the spec-kit `specify` CLI are pinned in the Dockerfile (the uv installer
+  URL carries the version; spec-kit is a `@vX.Y.Z` git tag). Bump per the comment above their `RUN`.
 
-After either bump, rebuild (`devcontainer build --workspace-folder .` or `make dev`) and confirm the
+After any bump, rebuild (`devcontainer build --workspace-folder .` or `make dev`) and confirm the
 image builds and hadolint stays green (via `make lint`).
 
-Not everything is pinned: the global CLIs baked into the Dockerfile (`uv`, the spec-kit `specify`
-CLI, `claude-code`) and the `gh` binary the `github-cli` feature installs still fetch their latest at
-build time — only the base image and the feature *packages* are pinned.
+Two tools are **deliberately left at `latest`**: the `claude-code` CLI (baked in the Dockerfile) and
+the `gh` binary (from the `github-cli` feature). They're agent/dev tooling we want fresh, and neither
+affects the CV build output — so they're outside Principle V's "pin what determines output". The
+inputs that *do* determine output (Node, the Playwright Chromium) are pinned via `package-lock.json`.
 
 > Without a Dev Container you can build with just Node + npm (`npm ci`), but you'll also need a
 > Chromium for the PDF and Docker for `make lint` / `make build`. The container is the supported path.


### PR DESCRIPTION
## Summary

Closes #88 (follow-up to #77). The `.devcontainer/Dockerfile` fetched **latest** for its baked CLIs at build time. Pin the low-churn ones for reproducibility (constitution Principle V); deliberately keep the fast-moving agent/dev tooling fresh.

## Changes

- **`uv`** — pinned to **0.11.26** via the versioned astral installer URL (`https://astral.sh/uv/0.11.26/install.sh`).
- **spec-kit `specify-cli`** — pinned to the **`@v0.12.4`** git tag (was installing from `main` HEAD).
- **`claude-code` and `gh`** — **deliberately left at `latest`** (owner decision). They're agent/dev tooling we want fresh and don't affect the CV build output, so they're outside Principle V's "pin what determines output". Documented as such (Dockerfile comment + docs).
- Refresh notes added: Dockerfile comment above the `RUN`, and the *Pinning* section of `docs/local-development.md` (new **Baked CLIs** bullet + updated "deliberately latest" note).

## Verification

- `devcontainer build` installs **uv 0.11.26** and **specify-cli 0.12.4** from the tag (confirmed in build output).
- `hadolint` exits 0; `markdownlint` clean.
- The inputs that actually determine the CV output (Node, Playwright Chromium) remain pinned via `package-lock.json` — unchanged.

## Note

Rebased onto latest `main` (picked up #93 cleanly — no overlap with the two files touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)