### PR TITLE
Vercel US2: DNS cutover runbook (docs)

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -126,6 +126,56 @@ deploys `--prod`; a `pull_request` deploys a preview whose URL is posted back to
   manual stack below. This section is a stopgap — the full CD rewrite (and removal of the manual
   stack) lands with the migration's Polish phase.
 
+### Domain cutover (DNS runbook)
+
+One-time migration of `valerio.dev` + `www.valerio.dev` from the GCP VM to Vercel (US2). The site is
+currently down and the VM is off, so this **restores** availability — there is **no rollback target
+and no downtime window to protect**. Run the steps in order.
+
+**1. Prepare (before touching DNS)**
+
+- **Verify serving first.** Merge to `main` (the `Deploy` workflow deploys `--prod`) and confirm the
+  production deployment renders: open its `*.vercel.app` URL **in a browser** and check the page
+  **and** the PDF render with the correct fonts. The production **TLS certificate** can't be verified
+  yet — Vercel issues it only after DNS points at Vercel (that check is step 4).
+- **⚠️ Check Deployment Protection** (Vercel → Project → Settings → Deployment Protection) — a hard
+  blocker. It must **not** protect production (set it to *Only Preview Deployments*, or off), or
+  `valerio.dev` is auth-walled (`302` → Vercel SSO) after cutover and the public CV is unreachable.
+  Preview URLs staying protected is expected — which is also why a `curl` of a `*.vercel.app` URL
+  returns `302` while protection is on, so verify serving in a browser (above) rather than with curl.
+- **Lower the DNS TTL.** Check the current TTL on the apex `A` and `www` records at the registrar
+  (e.g. 3600s), lower it (e.g. to 300s), and wait at least the *old* TTL so cached records expire —
+  then the cutover propagates quickly.
+
+**2. Add the domains in Vercel (T016 — owner, dashboard)**
+
+- Add `valerio.dev` and `www.valerio.dev` to the project.
+- Mark `valerio.dev` as the **primary** (canonical) domain.
+- Set `www.valerio.dev` to **Redirect to** `valerio.dev` (`301`).
+- Vercel then shows the exact records to set — an apex `A` IP and a `www` `CNAME` target. Use those
+  dashboard values, not the examples below.
+
+**3. Point DNS (T017 — owner, registrar)**
+
+- Apex: `A → 76.76.21.21` (use the IP shown in Vercel Domain settings).
+- `www`: `CNAME → <project>.vercel-dns-###.com` (exact target from the dashboard).
+- TLS is provisioned and renewed automatically by Vercel once DNS resolves to it — no certbot, no
+  manual renewal. The certificate is issued after DNS points at Vercel; verify it in step 4.
+
+**4. Verify the cutover (T018)**
+
+```sh
+dig A valerio.dev +short              # matches the A record shown in Vercel Domain settings
+curl -sI https://valerio.dev/         # 200, valid TLS; client Cache-Control: public, max-age=0
+                                      #   (edge-only s-maxage / stale-while-revalidate are stripped)
+curl -sI https://www.valerio.dev/     # 301 -> https://valerio.dev/
+```
+
+Vercel issues the certificate a few minutes after DNS points at it, so a TLS error on the first
+`curl` is normal — wait a few minutes and retry. Once the checks pass, load `https://valerio.dev/`
+in a browser and confirm the page and `/<slug>.pdf` render correctly over HTTPS; then you can restore
+a normal TTL. Retiring the VM stack itself is US3 (below is the stack being retired).
+
 ## Continuous Deployment — manual, Docker-based
 
 The site is self-hosted. Deployment is orchestrated by the `Makefile` and `docker-compose.yml`,

--- a/specs/001-vercel-cd-migration/tasks.md
+++ b/specs/001-vercel-cd-migration/tasks.md
@@ -101,7 +101,7 @@ apex. Restores the currently-down site. **Depends on US1** (a working prod deplo
 **Independent Test**: `dig`/`curl` show apex served over valid TLS and `www` → 301 → apex
 (quickstart Scenario 4).
 
-- [ ] T015 [US2] Write the DNS cutover runbook in `docs/` (e.g. a "Domain cutover" section of
+- [X] T015 [US2] Write the DNS cutover runbook in `docs/` (e.g. a "Domain cutover" section of
       `docs/ci-cd.md`): lower TTL → add domains in Vercel → set `www` → 301 → apex → verify serving +
       cert **before** switching → set A/CNAME → verify. Note there is no rollback (VM already down).
 - [ ] T016 [US2] **(owner-run — Vercel dashboard)** Add `valerio.dev` + `www.valerio.dev` to the


### PR DESCRIPTION
## Summary

Adds the **DNS cutover runbook** (task **T015**) — a "Domain cutover (DNS runbook)" section in
`docs/ci-cd.md` giving the owner an ordered, safe procedure to move `valerio.dev` + `www` from the
GCP VM to Vercel (US2). Docs-only.

## The runbook covers

1. **Prepare** — verify the production deployment serves (via its `*.vercel.app` URL in a browser);
   **⚠️ check Deployment Protection is off for production** (else `valerio.dev` gets auth-walled after
   cutover); lower the DNS TTL and wait out the old TTL.
2. **Add domains in Vercel** (T016, owner) — `valerio.dev` primary/canonical, `www` → `301` → apex.
3. **Point DNS** (T017, owner) — apex `A` + `www` `CNAME` to the dashboard values; Vercel
   auto-provisions TLS.
4. **Verify** (T018) — `dig` + `curl` checks (apex `200`/valid TLS, `www` `301` → apex), noting the
   cert is issued a few minutes after DNS points at Vercel.

Records the **no-rollback / restores-availability** framing (the VM is already down).

## Notes

- The **Deployment-Protection pre-check** was surfaced while verifying the US1 preview (previews
  return `302` → Vercel SSO); the runbook makes it a hard pre-cutover blocker so production isn't
  left unreachable.
- T016–T018 remain owner-run (Vercel dashboard + DNS registrar); this PR is the runbook that guides
  them. The full `ci-cd.md` deploy-model rewrite is the migration's Polish phase (T024).
- Self-review (independent): 6 findings, 5 applied (TLS-provisioning delay, serving-vs-cert split,
  concrete TTL wait, ⚠️ protection emphasis, edge-stripped Cache-Control note); 1 declined with
  reason (a `curl` `*.vercel.app` pre-check would mislead under Deployment Protection — browser check
  is correct).

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)