### PR TITLE
Plan: digital CV redesign (spec 002)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{"feature_directory":"specs/001-vercel-cd-migration"}
+{
+  "feature_directory": "specs/002-digital-cv-redesign"
+}

--- a/specs/002-digital-cv-redesign/checklists/requirements.md
+++ b/specs/002-digital-cv-redesign/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Digital CV redesign
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- Deliberately deferred to `/speckit-clarify` (not spec blockers — no reasonable single default):
+  the rendering-check **method** (visual-regression snapshots vs. assertion-based), exact
+  **breakpoint** values, the section-**navigation** style, and the **animation** scope. The spec
+  states these as outcomes (FR-002/003/004/007) and records the open decisions in Assumptions.

--- a/specs/002-digital-cv-redesign/contracts/rendering-contract.md
+++ b/specs/002-digital-cv-redesign/contracts/rendering-contract.md
@@ -1,0 +1,48 @@
+# Contract: rendering surface (screen vs. print)
+
+What the two outputs of the single build MUST satisfy. Both come from one Handlebars template + one
+CSS file; the divergence is CSS-media-driven (`@media screen` vs `@media print`). Verified by the
+visual-test gate (see [visual-test-gate-contract.md](visual-test-gate-contract.md)) and by inspecting
+the generated PDF.
+
+## Screen (digital page) — `@media screen`
+
+| Aspect | Requirement |
+|--------|-------------|
+| Layout | Content in **sections** with **card**-based items; scannable, not a flat wall of text (FR-001). |
+| Navigation | A **sticky section navigation** with anchor links to each section; collapses to a `<details>` menu on mobile; smooth-scroll gated by reduced-motion; `scroll-margin-top` offsets the sticky bar (FR-002). |
+| Responsiveness | Renders correctly at **all Bootstrap breakpoints** (375/576/768/992/1200/1440): no horizontal overflow, every section visible/legible, controls reachable (FR-004, SC-001). |
+| Animation | **Subtle** scroll-reveal (transform/opacity only); honors `prefers-reduced-motion`; no layout shift (FR-003, SC-005). |
+| Fallback | With **no JS** (or before the observer fires), all content is fully visible — never left `opacity:0` (edge case: progressive enhancement). |
+| Cross-link | A working **"Download PDF"** control is present (FR-006). |
+| Accessibility | Keyboard-navigable; reduced-motion respected; sufficient contrast (FR-011). |
+
+## Print / PDF — `@media print` (via `page.pdf()`, default print media)
+
+| Aspect | Requirement |
+|--------|-------------|
+| Form | A **clean, linear document** — identical in content and section order to today's PDF (FR-005, SC-004). |
+| Screen chrome | Sticky nav, card borders/shadows/backgrounds, and animations are **absent** (nav `display:none`/static; cards flattened; `animation/transition: none`). |
+| Pagination | Experience/competition entries use `break-inside: avoid` so a single entry is not split across pages. |
+| Cross-link | The **QR code** back to the page is present (FR-006). |
+| Generation | Produced by the **unchanged** `src/utils/pdf.js` (`page.pdf()`, default print media, A4, `page.pdf({margin})`). **No `emulateMedia` call** is added. |
+
+## Animation class contract
+
+- Elements that scroll-reveal carry the class **`.reveal`**.
+- Default (no JS) and reduced-motion state is **fully visible** — the hidden state is gated behind a
+  JS-set **`.js`** root class **and** `@media (prefers-reduced-motion: no-preference)`, so content is
+  never left `opacity:0` if JS fails.
+- `reveal.js` adds `.is-visible` (one-shot) to animate; `@media print` forces `.reveal` visible +
+  no motion; the test-only `tests/snapshot.css` forces `.reveal` to its final state for deterministic
+  snapshots.
+
+## Invariants across both
+
+- Same content, same order (content parity, SC-004).
+- One template, one CSS file; no separate print template; no `pdf.js` change.
+- Vendored fonts only (no CDN) — required for deterministic snapshots and offline builds.
+- **Static-only (FR-010)**: no backend/DB/API is introduced; the site still deploys as a static
+  artifact on the existing platform.
+- **Workflows intact (FR-012)**: local development and the existing build + deploy flows
+  (`npm start`, `make page`, `make dev-build`, the Vercel deploy) continue to work unchanged.

--- a/specs/002-digital-cv-redesign/contracts/visual-test-gate-contract.md
+++ b/specs/002-digital-cv-redesign/contracts/visual-test-gate-contract.md
@@ -1,0 +1,48 @@
+# Contract: visual-regression + PDF-render test gate
+
+The automated quality gate (FR-007/FR-008, SC-002). It is the safety net built first; the redesign is
+verified against it.
+
+## What it checks
+
+| Check | Definition | Pass condition |
+|-------|-----------|----------------|
+| Responsive rendering | Playwright `toHaveScreenshot({ fullPage: true })` of `dist/index.html` at each Bootstrap breakpoint (375/576/768/992/1200/1440) | Each screenshot matches its committed baseline within tolerance (`maxDiffPixelRatio: 0.01`, `threshold: 0.2`) |
+| PDF render | The build's `dist/*.pdf` | File exists, size > ~1 KB, and starts with the `%PDF-` header |
+
+**Out of scope for this gate**: keyboard navigation and colour-contrast (FR-011) are *not* checked by
+the visual/PDF gate — they are verified by manual review during the redesign. Automated accessibility
+assertions (e.g. axe-core) would add a dependency and are deferred as possible future work; the
+reduced-motion aspect of FR-011 *is* covered (via `reducedMotion: 'reduce'` in the capture).
+
+## How it runs
+
+- **Locally**: `make visual` — builds (`make page`) then runs the Playwright suite **inside the Dev
+  Container** (Linux), so results match CI. `make lint` / `make lint-fast` remain separate.
+- **CI**: `.github/workflows/visual.yml` on `ubuntu-latest` — `npm ci` → cache + `playwright install
+  --with-deps chromium` → `make page` → `npx playwright test`. **Required PR check.** On failure it
+  uploads the Playwright HTML report + diff images as an artifact.
+- **Loading**: the page is loaded as `file://…/dist/index.html` (same as `pdf.js`) — no server.
+
+## Determinism (required, or the gate is flaky)
+
+- Baselines are generated/compared **only in the Linux Dev Container / CI**; host (macOS) baselines
+  are never committed. A platform-neutral `snapshotPathTemplate` prevents a stray host run from
+  creating a divergent baseline.
+- `animations: 'disabled'` (default) + `reducedMotion: 'reduce'` + a test-only `stylePath`
+  (`tests/snapshot.css`, forcing `.reveal` visible) make the captured state deterministic despite the
+  IntersectionObserver reveal.
+- Vendored fonts (no CDN) + `document.fonts.ready` remove font/network nondeterminism.
+
+## Baseline update flow
+
+- Intentional visual changes are applied via **`make visual-update`** (wraps `playwright test
+  --update-snapshots` in the Dev Container). The regenerated PNGs are committed and **reviewed in the
+  PR** (GitHub's image diff). This is the *only* way baselines change.
+
+## Failure semantics
+
+- A responsive regression (overflow, hidden section), an **unintended** visual diff, or a PDF-render
+  failure → the check **fails and blocks the PR** before anything is published (SC-002).
+- CI never passes `--update-snapshots`, so a **missing baseline fails** (it does not silently create
+  one).

--- a/specs/002-digital-cv-redesign/data-model.md
+++ b/specs/002-digital-cv-redesign/data-model.md
@@ -1,0 +1,37 @@
+# Data model: Digital CV redesign
+
+No new data source or schema — CV content stays in `src/metadata/metadata.js` (unchanged, FR-009).
+This file records how that **existing** content maps to the redesign's presentation structure
+(sections, navigation entries, cards). It is a presentation model, not a persistence model.
+
+## Content sections (from `metadata.js`)
+
+The existing top-level content groups become the page's **sections** — each a navigation target and a
+titled block; their items render as **cards** on screen and flatten to linear blocks in print.
+
+| Section | Source key(s) in `metadata.js` | Screen presentation | Print presentation |
+|---------|-------------------------------|---------------------|--------------------|
+| Header / identity | `name`, `title`, `facts`, photo | Hero block; facts as inline items; **Download-PDF** button (screen-only) | Same identity block; **QR** to the page (print-only) |
+| About | `about_me` (Markdown) | Intro card | Linear paragraph |
+| Skills | `skills` (`[label, percent]`) | Skill cards / bars | Linear list/bars |
+| Professional experience | `positions[]` | One card per position | Linear entries (`break-inside: avoid`) |
+| Additional experience | `experience[]` | One card per entry | Linear entries |
+| Competitions | `competitions[]` | One card per entry | Linear entries |
+
+Experience-style entries keep their existing shape: `title`, `period`, `contents` (Markdown),
+`skills[]` (badges; omitted for competitions).
+
+## Derived: section navigation
+
+- Each section gets a stable **`id`** (e.g. `about`, `skills`, `experience`) used by the sticky nav's
+  anchor links and `scroll-margin-top`.
+- The **navigation list** is derived from the sections that are present/non-empty — a section with no
+  content is neither rendered nor listed (edge case: content edits must not leave a dangling nav
+  entry).
+
+## Invariants
+
+- **Content parity**: screen and PDF present the *same* content in the same order; only presentation
+  (chrome, cards, animation, nav) differs (FR-005, SC-004).
+- **No content added**: the redesign introduces no new fields, entities, or data source (FR-009).
+- **Cross-links**: the screen Download-PDF control and the print QR both resolve (FR-006).

--- a/specs/002-digital-cv-redesign/plan.md
+++ b/specs/002-digital-cv-redesign/plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan: Digital CV redesign — richer, responsive, card-based experience
+
+**Branch**: `002-digital-cv-redesign` | **Date**: 2026-07-02 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/002-digital-cv-redesign/spec.md`
+
+## Summary
+
+Make the **digital (screen)** CV a richer, responsive, card/section-based experience with a sticky
+section navigation and subtle, accessible animation — while keeping the **PDF** the same clean linear
+document and preserving the digital↔PDF cross-links. The work is **tests-first**: stand up a
+Playwright **visual-regression + PDF-render gate** (required on PRs) that locks today's rendering,
+then build the redesign against it. Everything stays a **single Handlebars source + one CSS file**;
+the rich screen chrome lives in the `@media screen` cascade and `@media print` strips it back to the
+existing linear PDF (`page.pdf()` already renders print media — `pdf.js` is untouched). See
+[research.md](research.md) for the decisions.
+
+## Technical Context
+
+**Language/Version**: JavaScript on Node.js 22 (existing build: `node src/build.js`); Handlebars
+templates; Bootstrap 5.2; hand-written CSS.
+
+**Primary Dependencies**: existing — `handlebars`, `playwright@1.61.1` (PDF render), `fs-extra`,
+`dayjs`, `speakingurl`, `markdown`, `@fontsource/roboto` + `@fortawesome/fontawesome-free` +
+`bootstrap` (vendored into `dist/`). **New (dev only)**: `@playwright/test@1.61.1` (test runner +
+`toHaveScreenshot`). Client-side: a few lines of vanilla JS (IntersectionObserver reveal); **no
+framework, no runtime deps, no animation library**.
+
+> **Maintenance constraint**: `playwright` and `@playwright/test` MUST stay pinned to the **same**
+> version (currently `1.61.1`) so they share the one pinned Chromium (no duplicate download / no
+> render drift). If one is bumped, bump both together.
+
+**Storage**: N/A — static site; CV content stays in `src/metadata/metadata.js`.
+
+**Testing**: Playwright (`@playwright/test`) — **visual-regression snapshots** at 6 Bootstrap
+breakpoints (375/576/768/992/1200/1440, `fullPage`) + a **PDF-render** check (exists / non-empty /
+`%PDF-` header). Baselines committed, generated only in the Linux Dev Container / CI. This is the
+repo's **first** automated test suite.
+
+**Target Platform**: static hosting on Vercel; modern evergreen browsers; PDF via headless Chromium.
+
+**Project Type**: single static web project (no backend).
+
+**Performance Goals**: main content visible < ~2.5 s on a typical mobile connection; no visible
+layout shift from animation (CLS ≈ 0).
+
+**Constraints**: no backend/DB/API; PDF output unchanged (content + linear form); snapshots must be
+deterministic (single Linux baseline env + vendored fonts + tolerance); minimal, pinned deps;
+`make` is the interface; builds/tests run in the Dev Container or CI, not the host.
+
+**Scale/Scope**: one CV page, ~6 content sections; 6 breakpoint baselines; 1 new CI workflow.
+
+## Constitution Check
+
+*GATE: evaluated pre-Phase 0 and re-checked post-design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Makefile is the interface | Pass (with action) | New targets `make visual` (build + run tests in Dev Container) and `make visual-update` (reviewed baseline refresh); added to `.PHONY`. |
+| II. Self-review before done | Pass | Each implementation PR runs `/code-review` + records the gate (unchanged). |
+| III. Docs stay in sync | Pass (with action) | Updates to `docs/ci-cd.md` (new gate), `docs/architecture.md` (screen/print split, tests), `docs/local-development.md` (`make visual*`), `AGENTS.md`; **ADR** for the visual-regression + screen/print-decoupling decision. |
+| IV. Validate locally; CI is the gate | **Conflict → amendment required** | Principle IV says *"There is no test suite… Linting is the only automated CI gate."* This feature **introduces a test suite and a second required CI gate.** Resolved by **amending Principle IV** (a Principle VI harness evolution) — see Complexity Tracking. The local-fast-loop + Dev-Container-not-host rules are honored (`make visual`). |
+| V. Reproducible and minimal | Pass | `@playwright/test` pinned to the same `1.61.1` as `playwright`; determinism via the pinned Chromium + vendored fonts + a single Linux baseline env + tolerance. Adds one dev dep + committed baseline PNGs (small). No SaaS, no framework. |
+| VI. Harness is a living system | Pass | The Principle IV amendment + the new gate are codified deliberately (constitution + docs + ADR), not patched ad-hoc. |
+| Development Workflow (tracking) | Pass | Tasks become GitHub issues via `/speckit-taskstoissues`; status via issues + milestone (per constitution v1.2.0 — needs PR #98 merged before `taskstoissues`). |
+
+**Gate result**: PASS, contingent on the Principle IV amendment (tracked, justified below). No
+unjustified violations.
+
+**Principle IV amendment (specifics for `/speckit-tasks`)**: reword the principle's *"There is no
+test suite… Linting is the only automated CI gate"* to acknowledge the new gate — e.g. *"Automated CI
+gates are Super-Linter (lint) and Playwright (visual-regression + PDF-render); reproduce them locally
+with `make lint` and `make visual` before pushing."* Bump the constitution **1.2.0 → 1.3.0** (MINOR —
+a principle materially changes) and update **Last Amended**; keep **`AGENTS.md`** consistent (its
+Testing Instructions gain the visual gate + `make visual` / `make visual-update`) and document the
+workflow in **`docs/ci-cd.md`**.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-digital-cv-redesign/
+├── plan.md              # This file
+├── research.md          # Phase 0 decisions
+├── data-model.md        # Phase 1 — content sections model
+├── quickstart.md        # Phase 1 — how to validate
+├── contracts/           # Phase 1 — rendering + test-gate contracts
+│   ├── rendering-contract.md
+│   └── visual-test-gate-contract.md
+└── tasks.md             # Phase 2 (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── templates/index.html     # MODIFY: sections + cards + sticky nav (screen-only chrome)
+├── assets/
+│   ├── styles.css           # MODIFY: extend screen/print split; card/nav/reveal styles; @media print flatten
+│   └── reveal.js            # NEW: tiny IntersectionObserver scroll-reveal (+ ".js" root-class gate)
+├── metadata/metadata.js     # UNCHANGED (content source)
+├── build.js                 # MODIFY only if needed to copy a new JS asset into dist/
+└── utils/pdf.js             # UNCHANGED (do NOT add emulateMedia — PDF stays print-media)
+
+tests/                       # NEW — first test suite
+├── visual.spec.js           # toHaveScreenshot per breakpoint (fullPage)
+├── pdf.spec.js              # PDF exists / non-empty / %PDF- header
+├── snapshot.css             # test-only: force .reveal visible for deterministic capture
+└── __screenshots__/         # committed Linux baselines
+
+playwright.config.js         # NEW (repo root): breakpoint projects, tolerance, reducedMotion, snapshotPathTemplate
+.github/workflows/visual.yml # NEW: required PR check (build + visual + pdf)
+Makefile                     # MODIFY: visual, visual-update targets (+ .PHONY)
+package.json / lock          # MODIFY: add @playwright/test@1.61.1 (dev)
+```
+
+**Structure Decision**: Single static project. The feature adds a **`tests/`** tree and a root
+**`playwright.config.js`** — the repo's first test infrastructure — plus screen-only enhancements to
+the existing template/CSS and one small client JS file. The PDF pipeline (`pdf.js`) is deliberately
+left untouched; screen/print divergence is entirely CSS-driven.
+
+## Complexity Tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+|-----------|------------|--------------------------------------|
+| **Amend Constitution Principle IV** ("no test suite / lint is the only CI gate") | The feature's core value is an automated visual-regression + PDF-render **gate** so responsive/PDF rendering can't silently break — inherently a test suite + a second CI gate. | Not adding tests leaves the redesign unguarded (defeats the P1 story + SC-002). Keeping Principle IV as-is while adding the gate would make the constitution self-contradictory. The amendment is the honest, minimal fix (Principle VI) — version-bumped, AGENTS.md kept consistent. |
+| **First `tests/` tree + `@playwright/test` dev dep + committed baseline PNGs** | Snapshot testing needs a runner, a config, and golden images. | jest-image-snapshot/BackstopJS add more tooling; SaaS (Percy) adds an external dependency + secret. Reusing the already-pinned Playwright is the minimal option. |

--- a/specs/002-digital-cv-redesign/quickstart.md
+++ b/specs/002-digital-cv-redesign/quickstart.md
@@ -1,0 +1,76 @@
+# Quickstart: validating the digital CV redesign
+
+Runnable checks that prove the feature works. All build/test steps run in the **Dev Container** (or
+CI), not the host (constitution IV / V). See [contracts/](contracts/) for the full rules.
+
+## Prerequisites
+
+- Dev Container up (`make dev` / VS Code "Reopen in Container").
+- `@playwright/test@1.61.1` installed (`npm ci`), Chromium present (`npx playwright install chromium`).
+
+## Scenario 1 — The gate passes on a good build (US1)
+
+**One-time baseline generation** (before the gate can pass — capture the current page as the golden
+reference, run in the Dev Container / Linux so baselines match CI):
+
+```sh
+make visual-update    # generates the baseline PNGs from the current page; commit them
+```
+
+Then validate that a no-op change passes:
+
+```sh
+make visual
+```
+
+Expected: `make page` builds `dist/` (HTML + PDF); the Playwright suite screenshots the page at all 6
+Bootstrap breakpoints and matches the committed baselines, and the PDF check passes. Exit 0.
+
+(During the P2/P3 redesign, intentional visual changes fail this check until `make visual-update` is
+re-run and the new baselines are committed + reviewed — see research.md "Baseline cadence".)
+
+## Scenario 2 — The gate catches a responsive regression (US1 / SC-002)
+
+Introduce a deliberate break (e.g. a fixed-width element wider than the mobile viewport), then:
+
+```sh
+make visual
+```
+
+Expected: the 375/576 snapshots fail with a pixel diff over tolerance; the job exits non-zero and (in
+CI) uploads diff images. Revert → `make visual` passes again.
+
+## Scenario 3 — The gate catches a broken PDF (US1)
+
+Force a PDF-render failure (e.g. break `src/utils/pdf.js` temporarily). Expected: `make visual` fails
+at the PDF check (missing / empty / no `%PDF-` header) **before** any deploy. Revert to restore.
+
+## Scenario 4 — Navigable, card-based screen; simple PDF (US2)
+
+Open `dist/index.html` in a browser at phone, tablet, and desktop widths. Expected: content in
+sections + cards, a sticky section nav (collapsing to a menu on mobile), no horizontal scrolling, a
+working **Download PDF** button. Open `dist/<slug>.pdf`: a clean linear document — **no** nav/cards
+chrome, content and order unchanged from before, **QR** present.
+
+## Scenario 5 — Motion is tasteful and accessible (US3)
+
+- Default: sections gently reveal on scroll; no layout jump.
+- OS "reduce motion" on: content appears immediately, no animation, fully usable.
+- JS disabled: all content is visible (nothing stuck hidden).
+
+## Scenario 6 — Intentional visual change (baseline update)
+
+Make a deliberate design change, then:
+
+```sh
+make visual-update   # regenerates baselines in the Dev Container
+```
+
+Expected: baseline PNGs update; commit them; the PR shows the before/after image diff for review.
+Without this step, the intended change would (correctly) fail `make visual`.
+
+## Success check
+
+- `make visual` green locally and as a **required PR check** in CI.
+- `make lint` still green; `npm start` / `make page` / `make dev-build` still work (no regression).
+- The PDF is unchanged in content + linear form; both cross-links resolve.

--- a/specs/002-digital-cv-redesign/research.md
+++ b/specs/002-digital-cv-redesign/research.md
@@ -1,0 +1,126 @@
+# Research: Digital CV redesign
+
+Phase 0 findings. Two parallel research passes: (A) deterministic CI-gated visual-regression with
+Playwright; (B) rich-screen / simple-PDF from one source + accessible animation. Decisions below feed
+`plan.md`, `data-model.md`, `contracts/`, and `quickstart.md`.
+
+## Decision 1 — Visual-regression tooling: `@playwright/test` `toHaveScreenshot()`
+
+- **Decision**: Add **`@playwright/test` pinned to `1.61.1`** (exact, devDependency — same version as the
+  existing `playwright` runtime dep) and use its built-in `toHaveScreenshot()` for snapshot testing.
+  The existing `src/utils/pdf.js` keeps importing `playwright` unchanged; the two coexist and share
+  the one version-pinned Chromium (no duplicate download) **because the versions match**.
+- **Rationale**: First-party, no external service, baselines live in-repo — fits the no-backend /
+  minimal-pinned-deps constraints. Reuses the browser we already pin.
+- **Alternatives**: Percy/Chromatic (external SaaS + secret + cost → rejected); jest-image-snapshot
+  (adds a second runner → rejected); BackstopJS (heavier wrapper + own config → rejected).
+
+## Decision 2 — Snapshot determinism (the flakiness risk of the chosen method)
+
+- **Decision**: Generate, update, and compare baselines **only in one consistent Linux environment**
+  (the Dev Container / CI `ubuntu-latest`) — never commit host/macOS baselines. Use a
+  **platform-neutral `snapshotPathTemplate`** (no `-darwin`/`-linux` suffix) so a stray host run
+  can't create a divergent baseline. Set tolerance `maxDiffPixelRatio: 0.01`, keep `threshold: 0.2`,
+  `animations: 'disabled'`, `scale: 'css'`, `caret: 'hide'` (last four are defaults, set explicitly).
+  Wait on `document.fonts.ready` (Playwright auto-waits for fonts). Baselines refresh only via a
+  reviewed `make visual-update` run in the Dev Container.
+- **Rationale**: Cross-OS font rasterization (CoreText vs FreeType) is the #1 visual-test flake; a
+  single Linux baseline source + the already-**vendored fonts (no CDN)** make rendering deterministic.
+  A small ratio tolerance absorbs antialiasing noise without hiding real regressions.
+- **Alternatives**: per-platform baselines (doubles maintenance, devs still can't reproduce CI →
+  rejected); zero tolerance (flaky on AA noise → rejected); the official `mcr.microsoft.com/playwright`
+  image (more infra vs. reusing the existing Dev Container → deferred, not needed).
+- **Baseline cadence (tests-first → redesign — important)**: the P1 gate captures baselines from the
+  **current, pre-redesign** page, locking today's look. The redesign (P2/P3) then *intentionally*
+  changes appearance, so those PRs will (correctly) fail the snapshot check until the author runs
+  **`make visual-update`** and commits the new baselines — which are **reviewed in the PR** (image
+  diff). So the gate does **not** block the redesign; it makes **every** visual change explicit and
+  reviewed, and catches only *unintended* diffs. Each redesign PR = code change + a reviewed baseline
+  update.
+
+## Decision 3 — Breakpoints
+
+- **Decision**: One representative width per Bootstrap 5 tier — **375 / 576 / 768 / 992 / 1200 /
+  1440** — captured `fullPage`. Six baselines.
+- **Rationale**: Covers every real device class the layout targets (Bootstrap xs/sm/md/lg/xl/xxl)
+  without excess surface.
+- **Alternatives**: 3 widths (misses xxl/edge tiers → the user chose the full set); every pixel
+  boundary (excessive → rejected).
+
+## Decision 4 — PDF-render assertion (same gate)
+
+- **Decision**: The Playwright suite also verifies the build's PDF: **exists, non-empty (> ~1 KB),
+  and begins with the `%PDF-` magic header** — zero new dependencies. Content-level assertions
+  (searching for the name/section headings) would need a parser (`pdf-parse`); **deferred** as an
+  optional later add to keep deps minimal.
+- **Rationale**: Catches the realistic failure (missing/empty/corrupt PDF) with no new dep, honoring
+  Principle V. The header+size check is a strong, cheap signal.
+- **Alternatives**: `pdf-parse` content assertions (one more dep → deferred); no PDF check (leaves the
+  PDF unguarded, and "PDF still renders" is an explicit spec goal → rejected).
+
+## Decision 5 — Rich screen + simple PDF from ONE source (screen/print CSS split)
+
+- **Decision**: Keep the **single Handlebars template + one CSS file**; extend the existing
+  `screen`/`print` split. `page.pdf()` renders **`print` media by default** (Playwright docs,
+  confirmed) and `src/utils/pdf.js` never calls `emulateMedia` — so the rich screen chrome lives in
+  the default/`@media screen` cascade and `@media print` strips it to today's linear document.
+  **`pdf.js` is NOT touched.** Screen-only chrome (sticky nav, cards, animation) goes in the existing
+  `.screen` bucket; `@media print` flattens cards (no border/shadow/background/radius), hides the nav,
+  and disables animation.
+- **Rationale**: One source of truth; the PDF stays simple *by construction* (it already depends on
+  default print media). No second template, no `pdf.js` change → PDF generation is not complicated.
+- **Alternatives**: a separate print template / separate PDF build (two sources to keep in sync →
+  rejected); emulating screen media for the PDF (would pull screen chrome into the PDF → rejected).
+- **Pitfalls**: `position: sticky/fixed` repeats on every printed page → keep nav screen-only /
+  `static` in print; backgrounds don't print by default (fine — don't rely on them in print); use
+  `break-inside: avoid` on experience entries so one isn't split across PDF pages; note the effective
+  PDF margin comes from `page.pdf({margin})`, not the `@page` CSS margin — keep them consistent.
+
+## Decision 6 — Animation: CSS + tiny IntersectionObserver, fail-safe
+
+- **Decision**: Scroll-reveal via CSS transitions on **`transform`/`opacity` only** + a small
+  one-shot **IntersectionObserver** (no library). Gate the hidden state behind a JS-set `.js`
+  root class **and** `@media (prefers-reduced-motion: no-preference)` so the **default (no-JS or
+  reduced-motion) is fully visible**; `@media print` forces visible + no motion.
+- **Rationale**: Dependency-free, no layout shift (compositor-only props → CLS ≈ 0), accessible
+  (reduced-motion honored), and **degrades gracefully** — content is never left `opacity:0` if JS
+  fails. Sticky nav uses `position: sticky` + anchor links + `scroll-behavior: smooth` (gated by
+  reduced-motion) + `scroll-margin-top`; the mobile menu is a `<details>`/`<summary>` disclosure
+  (zero JS, keyboard-accessible).
+- **Alternatives**: animation libraries (AOS/GSAP → unnecessary deps, rejected); base `opacity:0`
+  without the `.js` gate (blank content on JS failure → rejected footgun); `:target` CSS menu
+  (fights the anchor-scroll hash → rejected in favor of `<details>`).
+
+## Decision 7 — Making animation deterministic for snapshots
+
+- **Decision**: For visual tests, force the final rendered state via a test-only **`stylePath`
+  snapshot stylesheet** (`.reveal { opacity:1 !important; transform:none !important }`) **and**
+  Playwright `reducedMotion: 'reduce'`; rely on the built-in `animations: 'disabled'` for transitions.
+  Load the page as `file://dist/index.html` (same as `pdf.js`) — no server.
+- **Rationale**: Playwright disables CSS animations for screenshots but does **not** run the
+  IntersectionObserver, so below-the-fold reveals could stay hidden and snapshot nondeterministically.
+  Forcing the end state (via test-only CSS / reduced-motion) makes captures deterministic without
+  touching production CSS. `file://` matches how the PDF is already rendered — zero extra moving parts.
+- **Alternatives**: scroll the page to trigger the observer before capture (timing-fragile →
+  rejected); a local web server (more moving parts → deferred unless `file://` diverges).
+
+## Decision 8 — CI wiring
+
+- **Decision**: New workflow `.github/workflows/visual.yml` (name e.g. `Visual`), `ubuntu-latest`:
+  checkout → Node 22 + `npm ci` → cache `~/.cache/ms-playwright` (keyed on the Playwright version, per
+  `deploy.yml`) → `npx playwright install --with-deps chromium` → `make page` → `npx playwright test`
+  (compares committed baselines; **fails on a missing baseline** — CI never passes `--update-snapshots`)
+  → upload the Playwright HTML report + diff images as an artifact on failure. Make it a **required PR
+  check**. Local parity via **`make visual`** (build + test in the Dev Container) and **`make
+  visual-update`** (reviewed baseline refresh).
+- **Rationale**: Mirrors the existing `deploy.yml` build+cache pattern; `ubuntu-latest` matches the
+  Dev Container's Debian FreeType so baselines match. Principle I: the commands live in the Makefile.
+- **Alternatives**: fold into `deploy.yml` (mixes concerns; the deploy job shouldn't gate on pixels →
+  separate workflow); no CI (defeats the whole "can't silently break it" goal → rejected).
+
+## Cross-cutting note — Constitution Principle IV
+
+Principle IV currently states *"There is no test suite… Linting is the only automated CI gate."* This
+feature deliberately **introduces a test suite and a second required CI gate**, so Principle IV must be
+**amended** (a harness evolution under Principle VI). Tracked as a Constitution Check finding in
+`plan.md` and as a task; the amendment is a version-bumped constitution + AGENTS.md update.

--- a/specs/002-digital-cv-redesign/spec.md
+++ b/specs/002-digital-cv-redesign/spec.md
@@ -1,0 +1,196 @@
+# Feature Specification: Digital CV redesign — richer, responsive, card-based experience
+
+**Feature Branch**: `002-digital-cv-redesign`
+
+**Created**: 2026-07-02
+
+**Status**: Draft
+
+**Input**: User description: "Redesign the digital CV into a richer, responsive, card/section-based
+experience. The digital page is deliberately simple today because the same markup auto-generates the
+PDF; the drawback is the digital version is too plain and the (long) CV is hard to navigate. Make the
+digital (screen) experience more visually appealing and navigable — cards, sections, tasteful
+animation — across mobile/tablet/desktop, while keeping the PDF simple and auto-generated and
+preserving the digital↔PDF cross-links (screen Download-PDF button; print QR to the page). Decouple
+the rich screen presentation from the simple print output. Build an automated responsive/visual +
+PDF-render test gate FIRST, enforced on PRs. No backend/DB/API; content unchanged; framework
+migration out of scope unless strictly necessary."
+
+## Clarifications
+
+### Session 2026-07-02
+
+- Q: How should the automated rendering check decide the page renders correctly across breakpoints? → A: **Visual-regression snapshots** — screenshot each breakpoint and diff against committed baselines.
+- Q: How should a visitor navigate the long CV's sections on the digital page? → A: A **sticky section navigation** (section links that jump/scroll to sections; collapses to a menu on mobile).
+- Q: How much animation? → A: **Subtle** — micro-interactions + gentle scroll-reveal, reduced-motion-aware, no layout shift.
+- Q: Which viewport breakpoints should the redesign target and the check enforce? → A: **Bootstrap's full breakpoint set** (xs / sm / md / lg / xl / xxl).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Rendering can't silently break (Priority: P1)
+
+As the CV maintainer, I want an automated check that the page renders correctly on mobile, tablet,
+and desktop **and** that the PDF still renders, running as a required check on every pull request, so
+I can change the design confidently and never ship a broken layout or a broken PDF.
+
+**Why this priority**: It is the safety net that makes the rest of the redesign safe, and it already
+delivers value against the *current* page (regression protection) before any visual change lands.
+Tests-first: it locks today's good behavior so later stories can't regress it unnoticed.
+
+**Independent Test**: Open a PR that deliberately breaks a breakpoint layout (e.g. introduces
+horizontal overflow on mobile) or breaks PDF generation → the check fails and blocks the PR; revert →
+the check passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a change that renders correctly at all target breakpoints and still produces a valid
+   PDF, **When** a PR is opened, **Then** the rendering check passes.
+2. **Given** a change that introduces horizontal overflow (or hides a key section) at a mobile
+   breakpoint, **When** a PR is opened, **Then** the rendering check fails and reports which
+   breakpoint/section regressed.
+3. **Given** a change that breaks PDF generation, **When** a PR is opened, **Then** the check fails
+   before anything is published.
+4. **Given** a contributor before pushing, **When** they run the check locally, **Then** they get the
+   same pass/fail result as CI.
+
+---
+
+### User Story 2 - Navigable, card/section-based digital CV (Priority: P2)
+
+As a visitor (often a recruiter on a phone), I want the long CV presented as clear sections and cards
+with easy navigation, so I can scan it and jump to what's relevant quickly on any device.
+
+**Why this priority**: This is the core user-facing improvement — turning a long, plain page into a
+scannable, appealing experience — and the main reason for the initiative.
+
+**Independent Test**: Load the page on representative phone, tablet, and desktop viewports → content
+is organized into sections/cards, navigation between sections works, nothing overflows, and the PDF
+is unchanged (still a clean linear document).
+
+**Acceptance Scenarios**:
+
+1. **Given** the digital page on a desktop viewport, **When** it loads, **Then** the CV is presented
+   as distinct sections with card-based content and a visible way to navigate between sections.
+2. **Given** the digital page on a mobile viewport, **When** the visitor scans it, **Then** sections
+   and cards reflow to a single-column, legible layout with no horizontal scrolling.
+3. **Given** the redesigned page, **When** the PDF is generated from the same build, **Then** the PDF
+   remains a clean, simple, linear document — cards/section-navigation chrome do not appear in it.
+4. **Given** the redesigned page, **When** a visitor wants the file, **Then** the on-screen
+   "Download PDF" control works and the PDF still contains the QR code linking back to the page.
+
+---
+
+### User Story 3 - Tasteful motion & polish (Priority: P3)
+
+As a visitor, I want subtle, purposeful animation (e.g. content easing in as I scroll, gentle
+affordances on cards/navigation), so the page feels modern and polished — without distraction and
+without hurting performance or accessibility.
+
+**Why this priority**: A finishing enhancement layered on the P2 structure; valuable but not required
+for a usable, navigable redesign.
+
+**Independent Test**: On screen, animations play tastefully and honor a "reduced motion" preference
+(no animation when the user opts out); in the PDF, no animation/motion artifacts appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor with default settings, **When** they scroll/interact, **Then** subtle
+   animations enhance the experience without blocking content or causing layout shift.
+2. **Given** a visitor with "reduce motion" enabled, **When** they load the page, **Then**
+   non-essential animation is disabled and content is fully usable.
+
+---
+
+### Edge Cases
+
+- **Very small screens** (~320px): content stays legible with no horizontal overflow.
+- **Very long content / many sections**: navigation still lets a visitor reach any section quickly;
+  performance does not degrade noticeably.
+- **Print / PDF isolation**: screen-only chrome (cards styling, section navigation, animation) must
+  not leak into the print/PDF output, which stays a clean linear document.
+- **Reduced-motion / accessibility**: animations respect the OS "reduce motion" setting; the page
+  stays keyboard-navigable.
+- **Progressive enhancement**: if client-side JS fails to run, the CV content remains readable
+  (graceful degradation).
+- **Content edits**: adding/removing a CV entry in the content file must not break the layout or the
+  rendering checks.
+- **Intentional vs. accidental visual change**: because the check is visual-regression, a *deliberate*
+  redesign step updates the committed snapshot baselines (a reviewed change), whereas an *unintended*
+  visual diff fails the check. Snapshot determinism depends on the vendored fonts (no CDN) and a
+  consistent rendering environment.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The digital (screen) CV MUST present content as distinct **sections** with
+  **card-based** content, making a long CV easy to scan on mobile, tablet, and desktop.
+- **FR-002**: The digital page MUST provide a **sticky section navigation** — section links that
+  jump/scroll to each section, collapsing to a menu on mobile — suited to long content. It is
+  screen-only (excluded from the PDF).
+- **FR-003**: The digital page MUST use **subtle animation** — micro-interactions on cards/navigation
+  and a gentle scroll-reveal of sections — that honors the reduced-motion preference and causes no
+  layout shift.
+- **FR-004**: The page MUST render correctly — no horizontal overflow, key sections visible and
+  legible, controls reachable — across **Bootstrap's full breakpoint set (xs / sm / md / lg / xl / xxl)**.
+- **FR-005**: The **PDF MUST remain a clean, simple, linear document**; the redesign MUST NOT change
+  the PDF's content/form or complicate its generation. The screen and print presentations MAY diverge.
+- **FR-006**: The digital↔PDF **cross-links MUST be preserved**: the screen shows a working
+  "Download PDF" control; the PDF shows a QR code linking back to the page.
+- **FR-007**: An automated **visual-regression** check MUST screenshot the page at each target
+  breakpoint and compare against committed baselines, **and** verify the PDF renders correctly; it
+  MUST run as a **required check on pull requests** (failure blocks the PR before anything is
+  published). Intentional visual changes are accommodated by updating the committed baselines as a
+  reviewed step.
+- **FR-008**: The automated check MUST be **runnable locally** (a single command) so contributors get
+  the same result as CI before pushing.
+- **FR-009**: CV **content is unchanged** — it remains sourced from the existing content data file;
+  this feature changes presentation and navigation, not content.
+- **FR-010**: The site MUST remain a **static build** deployable on the existing platform with **no
+  backend, database, or API**; any interactivity is client-side only.
+- **FR-011**: The page MUST remain **accessible** — keyboard-navigable, sufficient contrast, and
+  respectful of reduced-motion preferences.
+- **FR-012**: Local development, the build pipeline, and the existing deploy flow MUST remain intact.
+
+### Key Entities *(include if feature involves data)*
+
+- **CV content sections**: the existing content groups (e.g. header/facts, about, skills, positions,
+  additional experience, competitions) sourced from the content data file — the units the redesign
+  organizes into sections/cards and navigation. No new content or data source is introduced.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Across **all Bootstrap breakpoints (xs/sm/md/lg/xl/xxl)** the page renders with **no
+  horizontal scrolling** and every major section visible and legible (verified by the
+  visual-regression check).
+- **SC-002**: A deliberately introduced responsive regression (e.g. mobile overflow, a hidden
+  section), an unintended visual change, or a PDF-render failure is caught by the check **100% of the
+  time** and blocks the PR.
+- **SC-003**: On a phone, a visitor can reach any major CV section in **under ~5 seconds** using the
+  page's navigation, rather than scrolling the entire long page as today.
+- **SC-004**: The generated **PDF is unchanged** by the redesign in content and structure — same
+  sections in the same linear order, Download-PDF and QR cross-links intact.
+- **SC-005**: On a typical mobile connection the page's main content is visible in **under ~2.5
+  seconds**, and animations cause **no visible layout jumping** as the page loads.
+- **SC-006**: The site still deploys as a **static** artifact (no backend/DB/API introduced).
+- **SC-007**: Contributors can run the rendering check locally and reproduce the CI result.
+
+## Assumptions
+
+- The existing Handlebars → HTML + PDF build pipeline is kept; a framework migration is **not**
+  undertaken unless planning finds it strictly necessary (deferred decision, out of scope here).
+- The existing screen/print CSS split (screen shows Download-PDF, print shows QR) is the seed for
+  decoupling the rich screen presentation from the simple print output.
+- The repo's existing headless-browser tooling (used today to render the PDF) is a suitable basis for
+  the automated rendering checks — no new external service is required.
+- Animation is **subtle** (micro-interactions + gentle scroll-reveal), reduced-motion-aware and
+  layout-shift-free (clarified 2026-07-02).
+- The rendering check uses **visual-regression snapshots** across **all Bootstrap breakpoints**
+  (clarified 2026-07-02). Snapshots must render deterministically — relying on the vendored fonts (no
+  CDN) and a consistent environment (the pinned headless browser in CI) to avoid cross-environment
+  flakiness; committed baselines are updated as a reviewed step for intentional visual changes.
+- CV content continues to live in the existing content data file; no CMS/API is added.
+- "Recruiter on a phone" is the primary audience for the digital experience; the PDF serves formal/
+  offline sharing.

--- a/specs/002-digital-cv-redesign/tasks.md
+++ b/specs/002-digital-cv-redesign/tasks.md
@@ -1,0 +1,141 @@
+# Tasks: Digital CV redesign — richer, responsive, card-based experience
+
+**Input**: Design documents from `specs/002-digital-cv-redesign/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: This feature's core deliverable **is** an automated test gate (US1), so test tasks are
+first-class and explicitly in scope.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, and Polish tasks carry no story label)
+
+**Organization**: tests-first. US1 (the visual + PDF gate) is the safety net; US2 (layout) and US3
+(animation) are built against it, each intentionally updating the reviewed snapshot baselines.
+
+## Phase 1: Setup (test tooling)
+
+- [T001](https://github.com/brunogbv/cv/issues/100) [P] Add `@playwright/test` pinned to `1.61.1` (exact, same as `playwright`) to
+      devDependencies in `package.json` and refresh `package-lock.json`.
+- [T002](https://github.com/brunogbv/cv/issues/101) [P] Add `playwright.config.js` at repo root: `testDir: 'tests'`; 6 breakpoint viewports
+      (375/576/768/992/1200/1440 = Bootstrap xs/sm/md/lg/xl/xxl); `expect.toHaveScreenshot`
+      `{ maxDiffPixelRatio: 0.01, threshold: 0.2, animations: 'disabled' }`; `use.reducedMotion:
+      'reduce'`; a platform-neutral `snapshotPathTemplate`; load pages via `file://` `dist/index.html`.
+- [T003](https://github.com/brunogbv/cv/issues/102) [P] Create `tests/snapshot.css` (test-only) forcing `.reveal { opacity:1 !important;
+      transform:none !important }` for deterministic capture.
+- [T004](https://github.com/brunogbv/cv/issues/103) Add `make visual` (build via `make page`, then run Playwright in the Dev Container) and
+      `make visual-update` (wraps `playwright test --update-snapshots` in the Dev Container) to the
+      `Makefile`, and add both to `.PHONY`.
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+No standalone foundational tasks. **US1 (Phase 3) is itself the foundation** — the test gate must be
+in place before US2/US3 so their visual changes are made explicit and reviewed. US2 and US3 depend on
+US1.
+
+## Phase 3: User Story 1 — Rendering can't silently break (Priority: P1) 🎯 MVP
+
+**Goal**: an automated visual-regression + PDF-render check, required on PRs, that locks today's
+rendering.
+
+**Independent test**: a deliberate mobile-overflow change or a broken PDF fails the check and blocks
+the PR; reverting turns it green (quickstart Scenarios 1–3).
+
+- [T005](https://github.com/brunogbv/cv/issues/104) [P] [US1] Write `tests/visual.spec.js`: `toHaveScreenshot({ fullPage: true })` of
+      `dist/index.html` at each of the 6 breakpoints (per `playwright.config.js`).
+- [T006](https://github.com/brunogbv/cv/issues/105) [P] [US1] Write `tests/pdf.spec.js`: assert the built `dist/*.pdf` exists, is > ~1 KB, and
+      begins with the `%PDF-` header.
+- [T007](https://github.com/brunogbv/cv/issues/106) [US1] Generate the initial baselines from the **current** page in the Linux Dev Container
+      (`make visual-update`) and commit `tests/__screenshots__/` (the pre-redesign golden reference).
+- [T008](https://github.com/brunogbv/cv/issues/107) [US1] Add `.github/workflows/visual.yml` (name `Visual`): `ubuntu-latest`, Node 22,
+      `npm ci`, cache `~/.cache/ms-playwright` (keyed on the Playwright version), `npx playwright
+      install --with-deps chromium`, `make page`, `npx playwright test`; upload the HTML report + diff
+      images as an artifact on failure. Enforce as a required PR check.
+- [T009](https://github.com/brunogbv/cv/issues/108) [US1] Verify the gate (quickstart Scenarios 1–3): a forced mobile overflow fails
+      `make visual`; a broken PDF fails `pdf.spec`; revert → green.
+
+**Checkpoint**: the safety net exists and is enforced; US2/US3 can proceed.
+
+## Phase 4: User Story 2 — Navigable, card/section-based digital CV (Priority: P2)
+
+**Goal**: rich, responsive card/section layout with a sticky section nav on screen; the PDF stays a
+clean linear document.
+
+**Independent test**: page shows sections/cards + working nav across breakpoints with no overflow;
+the PDF is unchanged (quickstart Scenario 4).
+
+- [T010](https://github.com/brunogbv/cv/issues/109) [US2] Extend the screen/print split in `src/assets/styles.css`: screen card + section
+      styles and sticky-nav styles; `@media print` flattens cards (no border/shadow/background/radius),
+      sets the nav `display:none`/static, and adds `break-inside: avoid` to experience/competition
+      entries.
+- [T011](https://github.com/brunogbv/cv/issues/110) [US2] Restructure `src/templates/index.html`: group content into sections with stable
+      `id`s (per data-model.md) + card markup; add the screen-only sticky section nav (in `.screen`)
+      with a mobile `<details>` menu; preserve the Download-PDF control (screen) and QR (print).
+- [T012](https://github.com/brunogbv/cv/issues/111) [US2] Add reduced-motion-gated `scroll-behavior: smooth` and `scroll-margin-top` for the
+      section anchors in `src/assets/styles.css`.
+- [T013](https://github.com/brunogbv/cv/issues/112) [US2] Verify: the PDF is unchanged (linear, no nav/card chrome, QR present, content order
+      intact); run `make visual-update` to accept the new screen look (reviewed baselines) and confirm
+      `make visual` green across all 6 breakpoints (quickstart Scenario 4).
+
+**Checkpoint**: the digital CV is navigable + card-based; the PDF is untouched.
+
+## Phase 5: User Story 3 — Tasteful motion & polish (Priority: P3)
+
+**Goal**: subtle, accessible scroll-reveal animation on screen; none in the PDF; graceful without JS.
+
+**Independent test**: gentle reveal on scroll with no layout shift; reduced-motion → no motion; no-JS
+→ content visible; PDF unaffected (quickstart Scenario 5).
+
+- [T014](https://github.com/brunogbv/cv/issues/113) [US3] Add `src/assets/reveal.js`: set a `.js` class on the root, then a one-shot
+      IntersectionObserver adding `.is-visible` to `.reveal` elements; ensure `src/build.js` copies it
+      into `dist/` and `src/templates/index.html` references it (screen-only).
+- [T015](https://github.com/brunogbv/cv/issues/114) [US3] Add reveal/animation CSS to `src/assets/styles.css`: `transform`/`opacity`
+      transitions gated behind `.js` **and** `@media (prefers-reduced-motion: no-preference)`; base
+      state fully visible (no-JS fallback); `@media print` forces `.reveal` visible + no motion.
+- [T016](https://github.com/brunogbv/cv/issues/115) [US3] Verify (quickstart Scenario 5): subtle reveal, CLS ≈ 0; reduced-motion off; no-JS
+      shows all content; snapshots deterministic via `tests/snapshot.css`; update baselines if the
+      resting state changed; `make visual` green.
+
+**Checkpoint**: full redesign complete, guarded by the gate.
+
+## Phase 6: Polish & cross-cutting
+
+- [T017](https://github.com/brunogbv/cv/issues/116) [P] Amend Constitution Principle IV in `.specify/memory/constitution.md` to acknowledge the
+      visual-regression + PDF-render CI gate; bump 1.2.0 → 1.3.0 + update Last Amended.
+- [T018](https://github.com/brunogbv/cv/issues/117) [P] Update `AGENTS.md`: Testing Instructions gain the visual gate + `make visual` /
+      `make visual-update` + the `tests/` suite (keep consistent with the constitution amendment).
+- [T019](https://github.com/brunogbv/cv/issues/118) [P] Update `docs/ci-cd.md`: document the `Visual` workflow, `make visual*`, and the
+      baseline-update flow.
+- [T020](https://github.com/brunogbv/cv/issues/119) [P] Update `docs/architecture.md`: the `tests/` suite, the screen/print decoupling, and
+      `reveal.js`.
+- [T021](https://github.com/brunogbv/cv/issues/120) [P] Update `docs/local-development.md`: add `make visual` / `make visual-update` to the
+      commands table.
+- [T022](https://github.com/brunogbv/cv/issues/121) [P] Add ADR `docs/adr/0003-visual-regression-and-screen-print-decoupling.md` recording the
+      decisions (visual-regression tooling + determinism, screen/print decoupling, accessible
+      animation) and update `docs/adr/README.md`.
+- [T023](https://github.com/brunogbv/cv/issues/122) Final verification: run quickstart Scenarios 1–6; `make lint` and `make visual` green;
+      confirm SC-001…SC-007.
+
+## Dependencies & execution order
+
+- **Setup (Phase 1)** → **US1 (Phase 3)** → **US2 (Phase 4)** → **US3 (Phase 5)** → **Polish (Phase 6)**.
+- US2 and US3 **depend on US1** (the gate must exist first; each then updates baselines intentionally).
+- Within US1: T005/T006 (write tests) before T007 (generate baselines) before T008/T009 (CI + verify).
+- Polish T017–T022 are independent files (parallel); T023 is last (depends on everything).
+
+## Parallel opportunities
+
+- **Phase 1**: T001, T002, T003 in parallel (different files); then T004.
+- **US1**: T005 and T006 in parallel (separate spec files).
+- **Polish**: T017–T022 in parallel (six independent files).
+
+## Implementation strategy
+
+- **MVP = US1** (the gate) — delivers standalone value (regression protection on the current page)
+  and unblocks the rest.
+- Then US2 (the visible redesign), then US3 (motion). Each US2/US3 change ships as code **plus a
+  reviewed baseline update** (see research.md "Baseline cadence") — the gate makes every visual change
+  explicit, never blocking intended ones.
+- Polish (docs + the Principle IV amendment + ADR) lands with or right after the stories it documents.


### PR DESCRIPTION
## Summary

Persists the **spec-kit planning artifacts** for the *Digital CV redesign* initiative (spec →
clarify → plan → tasks). **Planning only — no implementation.**

`specs/002-digital-cv-redesign/`: `spec.md`, `plan.md`, `research.md`, `data-model.md`,
`contracts/` (rendering + visual-test-gate), `quickstart.md`, `tasks.md`, `checklists/requirements.md`;
plus `.specify/feature.json` repointed to `002`.

## The initiative

Make the **digital** CV richer + responsive (card/section layout, sticky nav, subtle animation) while
keeping the **PDF** a clean linear document and preserving the digital↔PDF cross-links.

- **Tests-first**: US1 is a Playwright **visual-regression + PDF-render CI gate** (locks today's
  rendering); US2 (layout) and US3 (animation) build against it, each shipping code **+ a reviewed
  baseline update**.
- **Single source**: rich screen via `@media screen`, simple PDF via `@media print` — `page.pdf()`
  already renders print media, so **`pdf.js` is untouched**.
- **No backend/DB/API**; content unchanged; deterministic snapshots (Linux-only baselines + vendored
  fonts + tolerance).

## Tracking (per #98)

23 tasks → **issues #100–#122** under the new **"Digital CV redesign"** milestone; each `tasks.md`
checkbox is a link to its issue (status lives in GitHub, not the file). Task issues will be closed by
their implementation PRs, not this one.

## Constitution note

The Constitution Check flags a **Principle IV conflict** (this feature adds a test suite + a second
CI gate, which the principle currently forbids). Resolved by an **amendment to v1.3.0**, tracked as
task **T017** (#116).

## Review

Reviewed across the flow — spec self-review (clean) and plan self-review (7 findings, all fixed);
markdownlint clean. Persisting reviewed planning artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)