### PR TITLE
Make the Dev Container check requireable without deadlocking (#128)

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -5,10 +5,14 @@ name: Dev Container
 # (on any machine and in each `make worktree`) pulls cached layers instead of
 # building the image from scratch. See docs/ci-cd.md.
 #
-# Runs when the image's inputs change: the .devcontainer/ dir, the manifests the
-# Dockerfile bakes in (package.json / package-lock.json drive the Playwright
-# layer), or this workflow. Pull requests build + smoke-test without publishing;
-# pushes to main publish.
+# This check is *required* on main, so it must report a status on every PR or a
+# required-but-never-run check would block merges forever. It therefore runs on
+# all pull requests (no trigger-level paths filter) and skips the heavy build
+# when no Dev Container inputs changed — a skipped build still reports success,
+# so unrelated PRs aren't blocked. When the inputs *do* change (the .devcontainer/
+# dir, the manifests the Dockerfile bakes in — package.json / package-lock.json —
+# or this workflow), it builds + smoke-tests the image. Pushes to main also
+# publish; pull requests build + smoke-test without publishing.
 
 on:
   push:
@@ -19,11 +23,6 @@ on:
       - package-lock.json
       - .github/workflows/devcontainer.yml
   pull_request:
-    paths:
-      - .devcontainer/**
-      - package.json
-      - package-lock.json
-      - .github/workflows/devcontainer.yml
   workflow_dispatch:
 
 permissions:
@@ -37,8 +36,34 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so the change-detection diff can reach the PR base commit.
+          fetch-depth: 0
+
+      # Requireable-without-deadlock: the workflow runs on every PR, but the heavy
+      # build below only runs when Dev Container inputs changed. On PRs that don't
+      # touch them this job still completes green, satisfying branch protection.
+      - name: Detect Dev Container changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- \
+              .devcontainer package.json package-lock.json \
+              .github/workflows/devcontainer.yml | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: No Dev Container changes — skip build
+        if: github.event_name == 'pull_request' && steps.changes.outputs.changed != 'true'
+        run: echo "No .devcontainer/ or package manifest changes in this PR; skipping the Dev Container build and reporting success."
 
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request' || steps.changes.outputs.changed == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -53,6 +78,7 @@ jobs:
       # not publish. `cacheFrom` reuses the last published image's layers so
       # unchanged builds are near-instant.
       - name: Build, smoke-test, and publish the Dev Container image
+        if: github.event_name != 'pull_request' || steps.changes.outputs.changed == 'true'
         uses: devcontainers/ci@v0.3
         with:
           imageName: ghcr.io/${{ github.repository_owner }}/cv-devcontainer

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -85,9 +85,11 @@ Caveats:
 publishes it to the GitHub Container Registry (GHCR), so `devcontainer up` — on any machine and in
 each `make worktree` — pulls cached layers instead of building the image from scratch.
 
-- **Triggers:** `push` to `main` and `pull_request`, both filtered to the paths that determine the
-  image (`.devcontainer/**`, `package.json`, `package-lock.json`, and the workflow file); plus
-  manual `workflow_dispatch`.
+- **Triggers:** runs on **every** pull request (so it can be a required check — see below) and on
+  `push` to `main` filtered to the paths that determine the image (`.devcontainer/**`,
+  `package.json`, `package-lock.json`, and the workflow file); plus manual `workflow_dispatch`. On a
+  PR it first detects whether those inputs changed and **skips the build (reporting success) when
+  they didn't**, so unrelated PRs stay fast and unblocked.
 - **What it does:** logs in to GHCR (`docker/login-action`, `packages: write` + `GITHUB_TOKEN`),
   then `devcontainers/ci@v0.3` builds the image (Dockerfile + features), runs the container
   lifecycle (`postCreate`: `npm ci` + `playwright install`), and runs **`make page`** inside it as a
@@ -100,6 +102,13 @@ each `make worktree` — pulls cached layers instead of building the image from 
   so `devcontainer up` reuses the published layers (near-instant when unchanged). If the registry is
   unreachable or the image is missing, the build simply falls back to a normal local build — the
   prebuild is an optimization, never a hard dependency.
+- **Required check (no deadlock):** because the job runs and reports on every PR — building when the
+  inputs changed, skipping *green* when they didn't — `Build, smoke-test, and publish` is a
+  **required** status check on `main`, alongside `Lint`, `Visual + PDF checks`, and `Build and
+  deploy`. A path-filtered check *can't* be required: on PRs that don't touch its paths it never
+  runs, so a required context waits "Expected" forever and blocks the merge. Dropping the
+  trigger-level `paths` filter from `pull_request` (and skipping the build in-job instead) is what
+  makes it safe to require.
 
 **One-time owner step (manual):** for anonymous pulls to work — so contributors get the cache
 without a `docker login` — the GHCR package must be **public**. After the first publish from `main`,


### PR DESCRIPTION
## Summary

Closes #128. The **Dev Container** check (`Build, smoke-test, and publish` — builds the image and smoke-tests `make page`) was path-filtered at the trigger level, so it couldn't be added to branch protection: on any PR that doesn't touch `.devcontainer/**` / `package*.json`, it never ran, leaving a required context stuck at *"Expected — waiting for status"* and blocking the merge forever.

## Change

Rework `.github/workflows/devcontainer.yml` so the check **always reports a status on PRs**:

- **Drop the trigger-level `paths` filter from `pull_request`** → the workflow runs on every PR.
- **Detect changes in-job** (`git diff <base.sha> <head.sha>` over `.devcontainer/`, `package.json`, `package-lock.json`, and the workflow file). When nothing relevant changed, the login/build steps are skipped and the job reports **success**. Crucially the *job* always runs (only its heavy *steps* skip), so there's no skipped-required-check ambiguity and no deadlock.
- When the inputs **do** change, it builds + smoke-tests exactly as before.
- **Publish-on-`main` is unchanged:** the `push` trigger keeps its `paths` filter and `devcontainers/ci`'s `push: filter` still publishes only on default-branch pushes.

Same job name (`Build, smoke-test, and publish`), so the required-check context is stable.

## Verification (cheap + deterministic)

- `actionlint` (native, pinned 1.7.1) on the reworked workflow → **exit 0**.
- YAML parse confirms `pull_request` now has no path filter while `push` keeps one.
- `markdownlint` clean.
- Gate logic (`github.event_name != 'pull_request' || steps.changes.outputs.changed == 'true'`): push/dispatch → build (+publish on main push); PR w/ changes → build; PR w/o changes → skip → **green**.
- This PR touches the workflow file, so the current (pre-merge) check runs and reports on it.

## Post-merge step (branch protection)

Adding `Build, smoke-test, and publish` to `main`'s required checks must happen **after** this lands (the always-reporting behavior needs to be on `main` first). Current required set: `Lint`, `Visual + PDF checks`, `Build and deploy` (strict/up-to-date on). I can add it via the API once merged, or hand it off — see the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)