### PR TITLE
Align local markdownlint (make lint-fast) with CI's MD013 line-length

### DIFF
--- a/config/lint/markdownlint-fast.json
+++ b/config/lint/markdownlint-fast.json
@@ -2,7 +2,7 @@
   "default": true,
   "MD004": false,
   "MD012": false,
-  "MD013": false,
+  "MD013": { "line_length": 400 },
   "MD031": false,
   "MD032": false,
   "MD033": false,

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -74,6 +74,11 @@ Caveats:
   arm64** (and says so); check workflows with **`make lint-actions`**, which runs actionlint natively
   (pinned to the version Super-Linter bundles). On amd64 (CI/Intel) nothing is skipped. `make
   lint-fast` stays the quick inner-loop check.
+- **Markdown line-length:** `make lint-fast`'s markdownlint config
+  (`config/lint/markdownlint-fast.json`) mirrors Super-Linter's **MD013 `line_length: 400`** (and its
+  default table/code-block behaviour), so an over-length line — e.g. a wide table row that can't wrap
+  — now fails `lint-fast` as it does in CI. Native `markdownlint-cli2` and Super-Linter's bundled
+  markdownlint can still differ on newer/edge rules; `make lint` remains the exact mirror.
 - **Scope:** locally, Super-Linter lints the whole workspace; in CI it lints only files changed
   against `main`. Local is broader, not narrower.
 - **Vercel:** the deploy-preview check runs on Vercel's side and is **not** covered by `make lint`;


### PR DESCRIPTION
## What

`make lint-fast` **disabled MD013** while CI's Super-Linter enforces it at **`line_length: 400`**, so an over-length Markdown line passed locally but failed CI. This bit PR #123 — a `plan.md` with 421- and 546-char **table rows** (which can't wrap) — and only surfaced after merge (fixed in #124). Local lint should have caught it.

## Change

- **`config/lint/markdownlint-fast.json`** — `"MD013": false` → `"MD013": { "line_length": 400 }`, mirroring Super-Linter's bundled `.markdown-lint.yml` (extracted from the pinned `super-linter:v6.7.0` image). Left `code_blocks`/`tables` at their defaults (`true`), exactly as Super-Linter does — that default is *why* wide table rows are caught.
- **`docs/ci-cd.md`** — added a "Markdown line-length" caveat documenting the parity and the residual approximation (native `markdownlint-cli2` vs Super-Linter's bundled markdownlint can still differ on newer/edge rules; `make lint` is the exact mirror).

## Acceptance criteria (#125)

- [x] `markdownlint-fast.json` enforces MD013 at 400 to match CI.
- [x] A Markdown line > 400 chars now **fails `make lint-fast`** — verified: `MD013/line-length [Expected: 400; Actual: 550]`.
- [x] Existing repo Markdown still passes `make lint-fast` — verified: **30 files, 0 errors** (`.claude/skills/**` and `.specify/**` excluded as before).
- [x] Parity noted in `docs/ci-cd.md` caveat list.

## Notes

- **No CI-behavior change:** CI uses Super-Linter's own bundled config; `markdownlint-fast.json` is consumed only by local `make lint-fast`. This purely tightens local to match CI.
- MD013 was the **only** real divergence: the local config's other disables (MD012/MD031/MD032) already match Super-Linter, which disables them via its `blank_lines: false` tag.

## Verification

- `markdownlint-cli2@0.23.0` (the version `lint-fast` pins) over the exact `lint-fast` globs — 0 errors; synthetic >400-char line correctly flagged.
- `make lint` (Super-Linter v6.7.0, the CI gate) — **green**, all languages.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
