### PR TITLE
US3: subtle, accessible scroll-reveal

### DIFF
--- a/src/assets/reveal.js
+++ b/src/assets/reveal.js
@@ -1,0 +1,45 @@
+/* global IntersectionObserver */
+// Scroll reveal (US3) — progressive enhancement, loaded synchronously from <head>.
+//
+// Adding `.js` to the root element BEFORE first paint lets styles.css hold `.reveal` elements hidden
+// until they scroll into view (no flash of pre-revealed content). A one-shot IntersectionObserver then
+// marks each element `.is-visible` as it enters the viewport. The enhancement is designed to FAIL
+// VISIBLE: with no JavaScript `.js` is never set and content stays fully visible; if the observer is
+// unavailable or setup throws for any reason, every `.reveal` is revealed immediately. Motion is also
+// disabled for reduced-motion users and in print (see styles.css), so this only ever adds a subtle
+// on-screen entrance.
+document.documentElement.classList.add('js')
+
+const revealAll = () => {
+  document.querySelectorAll('.reveal').forEach((el) => el.classList.add('is-visible'))
+}
+
+const setup = () => {
+  try {
+    const reveals = document.querySelectorAll('.reveal')
+    if (!reveals.length || !('IntersectionObserver' in window)) {
+      revealAll()
+      return
+    }
+
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return
+        entry.target.classList.add('is-visible')
+        obs.unobserve(entry.target)
+      })
+    })
+
+    reveals.forEach((el) => observer.observe(el))
+  } catch {
+    // Never leave content stuck hidden if observer setup fails for any reason.
+    revealAll()
+  }
+}
+
+// The script runs in <head>, so wait for the body before querying for `.reveal` elements.
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setup)
+} else {
+  setup()
+}

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -357,3 +357,29 @@ h4 {
         margin-bottom: 1.5rem;
     }
 }
+
+/* ---- Scroll reveal (US3): subtle, accessible entrance animation ----
+   Base state is fully visible — the no-JS fallback (see reveal.js). Only once reveal.js has set `.js`
+   on the root AND the visitor has not requested reduced motion do `.reveal` elements start hidden and
+   ease in when marked `.is-visible`. Only opacity/transform animate, so there is no layout shift. */
+@media (prefers-reduced-motion: no-preference) {
+    .js .reveal {
+        opacity: 0;
+        transform: translateY(1.5rem);
+        transition: opacity 0.5s ease, transform 0.5s ease;
+    }
+
+    .js .reveal.is-visible {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+/* Never hide or animate in the PDF, regardless of `.js`/observer state (mirrors tests/snapshot.css). */
+@media print {
+    .reveal {
+        opacity: 1 !important;
+        transform: none !important;
+        transition: none !important;
+    }
+}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -12,6 +12,11 @@
     <link rel="stylesheet" href="vendor/bootstrap/bootstrap.min.css">
     <link rel="stylesheet" href="vendor/fontawesome/css/all.min.css">
     <link rel="stylesheet" href="styles.css">
+    <!-- Loaded synchronously so `.js` is set before first paint (no flash of pre-revealed content);
+         reveal.js then wires the scroll-reveal observer once the DOM is ready. Progressive enhancement:
+         with no JS the content stays fully visible, and the effect is screen-only (styles.css keeps
+         `.reveal` visible in print). -->
+    <script src="reveal.js"></script>
     <base target="_blank">
 </head>
 
@@ -79,7 +84,7 @@
 
         <main>
         {{#if about_me}}
-        <section id="about" class="cv-section">
+        <section id="about" class="cv-section reveal">
             <h2 class="cv-section-title">About me</h2>
             <div class="card cv-card">
                 <div class="card-body">{{{markdown about_me}}}</div>
@@ -91,7 +96,7 @@
         <!-- Skills keep their original grid markup (no card wrapper): the dot-bars use a Bootstrap
              `.row` whose gutters render subtly differently inside a card box in print, so keeping the
              structure identical guarantees the PDF's skills grid is unchanged (FR-005 / SC-004). -->
-        <section id="skills" class="cv-section">
+        <section id="skills" class="cv-section reveal">
             <h2 class="cv-section-title">Skills</h2>
             <div class="row align-items-center">
                 {{#each skills}}
@@ -109,7 +114,7 @@
         {{/if}}
 
         {{#if positions}}
-        <section id="experience" class="cv-section">
+        <section id="experience" class="cv-section reveal">
             <h2 class="cv-section-title">Professional Experience</h2>
             {{#each positions}}
             <div class="card cv-card cv-entry {{#unless @last}}mb-5{{/unless}}">
@@ -135,7 +140,7 @@
         {{/if}}
 
         {{#if experience}}
-        <section id="additional" class="cv-section">
+        <section id="additional" class="cv-section reveal">
             <h2 class="cv-section-title">Additional Experience</h2>
             {{#each experience}}
             <div class="card cv-card cv-entry {{#unless @last}}mb-5{{/unless}}">
@@ -161,7 +166,7 @@
         {{/if}}
 
         {{#if competitions}}
-        <section id="competitions" class="cv-section">
+        <section id="competitions" class="cv-section reveal">
             <h2 class="cv-section-title">Robotics Competitions</h2>
             {{#each competitions}}
             <div class="card cv-card cv-entry {{#unless @last}}mb-5{{/unless}}">


### PR DESCRIPTION
Implements **User Story 3** of the digital CV redesign (spec `002-digital-cv-redesign`): tasteful, accessible motion — sections gently ease in as they scroll into view.

## What changed
- **`src/assets/reveal.js`** — sets `.js` on the root *before first paint* (no flash), then a one-shot `IntersectionObserver` marks each `.reveal` section `.is-visible` as it enters the viewport. Copied to `dist/` by the existing assets copy in `build.js`.
- **`styles.css`** — `.reveal` starts hidden (opacity + `translateY`) **only** when `.js` is set **and** `prefers-reduced-motion: no-preference`; `.is-visible` eases it in. Only `opacity`/`transform` animate → **no layout shift**. `@media print` forces `.reveal` visible.
- **Template** — loads `reveal.js` from `<head>`; adds `.reveal` to the five sections.

## Accessible & robust — fails *visible*, not hidden
The whole point of a CV is that the content is readable, so the enhancement degrades safely (verified with Playwright):
- **No JS** → `.js` never set → content fully visible.
- **No `IntersectionObserver`** (or any setup error) → reveal-all fallback fires → content fully visible.
- **`prefers-reduced-motion: reduce`** → animation opted out, content visible.
- **PDF** → `@media print` forces `.reveal` visible; the generated PDF is **unchanged** (verified page-for-page, same byte size).

## Self-review (`/code-review`)
A reviewer flagged that the reveal could "fail hidden." Fixed before commit: added the reveal-all fallback + a try/catch around observer setup, and dropped a negative `rootMargin` that could have stranded the last section at `opacity:0`.

## Test gate
`make visual` green (7 passed) with **baselines unchanged** — the gate runs under `reducedMotion: reduce` + `tests/snapshot.css`, so the resting state is identical to US2. `make lint` green.

Closes #113
Closes #114
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)