### PR TITLE
Polish: document the redesign + amend the constitution

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -22,12 +22,16 @@ A change that alters behavior, commands, architecture, or workflow updates the r
 same PR (`docs/`, `README.md`, `AGENTS.md`). Significant, expensive-to-reverse decisions are
 captured as an ADR in `docs/adr/`.
 
-### IV. Validate locally; CI is the gate
+### IV. Validate locally; CI gates are the safety net
 
-Linting (Super-Linter) is the only automated CI gate — reproduce it with `make lint` before
-pushing. There is no test suite; quality comes from lint + self-review + verifying the generated
-PDF. Keep the feedback loop local and fast. Builds and PDF rendering run in the Dev Container or CI,
-not the host — see [`docs/local-development.md`](../../docs/local-development.md).
+Two automated CI gates run on every PR and must pass: **linting** (Super-Linter, `make lint`) and the
+**visual-regression + PDF-render check** (Playwright, `make visual`). Reproduce both locally before
+pushing. The visual gate snapshots the page at each breakpoint and verifies the PDF renders;
+intentional visual changes update the committed baselines (`make visual-update`) as a reviewed step.
+There is no *unit/integration* suite — beyond the automated gates, quality still comes from
+self-review and inspecting the generated PDF. Keep the feedback loop local and fast. Builds, PDF
+rendering, and the visual check run in the Dev Container or CI, not the host — see
+[`docs/local-development.md`](../../docs/local-development.md).
 
 ### V. Reproducible and minimal
 
@@ -58,4 +62,4 @@ that links its issue with `Closes #<n>`.
 This constitution reflects and defers to [`AGENTS.md`](../../AGENTS.md); amendments update both and
 keep them consistent. All PRs are expected to comply, and added complexity must be justified.
 
-**Version**: 1.2.0 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-02
+**Version**: 1.3.0 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-03

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,12 +59,21 @@ Deploy is **automatic** — see [`docs/ci-cd.md`](docs/ci-cd.md):
 
 ## Testing Instructions
 
-- There are **no** unit or integration tests in this repo.
+- The automated test gate is **visual-regression + PDF-render** (Playwright), not a unit/integration
+  suite: `tests/visual.spec.js` snapshots the page at the six Bootstrap breakpoints against committed
+  baselines (`tests/__screenshots__/`), and `tests/pdf.spec.js` asserts the build produced a valid
+  PDF. It runs as a **required PR check** (`.github/workflows/visual.yml`, name `Visual + PDF checks`)
+  alongside linting.
 - **Validate locally before pushing.** During iteration use `make lint-fast` (fast native JS +
-  Markdown lint) and/or the Dev Container's editor extensions; before opening/updating a PR run
-  `make lint` — it runs the *same* Super-Linter image CI uses (linting is the CI gate for code and
-  content changes), so you catch failures locally instead of waiting on the push-and-wait PR cycle.
+  Markdown lint) and/or the Dev Container's editor extensions; before opening/updating a PR run both
+  `make lint` (the *same* Super-Linter image CI uses) and `make visual` (Playwright in the pinned
+  image), so you catch lint and rendering failures locally instead of on the push-and-wait PR cycle.
   See [`docs/ci-cd.md`](docs/ci-cd.md) for details and caveats.
+- **Visual baselines:** `make visual` checks the current render against the committed baselines; when
+  a change *intentionally* alters the page, regenerate them with `make visual-update` and commit the
+  updated PNGs (a reviewed step). Both run in the pinned Playwright image
+  (`mcr.microsoft.com/playwright:v1.61.1-noble`) so local rendering matches CI — the #1 snapshot flake
+  is cross-environment font rendering.
 - Linting via Super-Linter runs on every push/PR (`.github/workflows/superlinter.yml`); `make lint`
   reproduces it locally — including on Apple Silicon (it runs the amd64 image emulated) and from a
   `make worktree` sibling. On arm64 it skips the GitHub Actions validator (actionlint segfaults under

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Everything goes through the `Makefile`. The common targets:
 - **`make lint-fast`** — quick JavaScript + Markdown lint for the inner loop.
 - **`make lint-actions`** — `actionlint` on the GitHub Actions workflows.
 
+### Test
+
+- **`make visual`** — the visual-regression + PDF-render gate (Playwright, pinned image); a required
+  PR check that snapshots the page at every breakpoint and verifies the PDF builds.
+- **`make visual-update`** — regenerate the committed snapshot baselines after an *intentional* visual
+  change (a reviewed step; commit the PNGs).
+
 ### Deploy
 
 Deployment is **automatic** — GitHub Actions builds and deploys to Vercel on every push (production

--- a/docs/adr/0003-visual-regression-and-screen-print-decoupling.md
+++ b/docs/adr/0003-visual-regression-and-screen-print-decoupling.md
@@ -1,0 +1,82 @@
+# 0003 — Visual-regression gate + screen/print decoupling for the CV redesign
+
+- **Status:** Accepted — implemented across the `002-digital-cv-redesign` milestone (US1 #126,
+  US2 #132, US3 #133, Polish); issues #100–#122
+- **Date:** 2026-07-03
+
+## Context
+
+The digital CV was deliberately kept visually plain because the **same** Handlebars markup generates
+both the on-screen page and the PDF (via Playwright `page.pdf()`), so any screen richness risked
+complicating the PDF. We wanted a richer, responsive, card/section-based screen experience with a
+sticky nav and subtle motion — without regressing the clean, linear PDF, and without a way for such a
+redesign (or any future change) to silently break rendering on some device or break the PDF.
+
+Forces:
+
+- **No test suite existed** — linting was the only automated gate (old constitution Principle IV), so
+  a CSS/layout regression could ship unnoticed. A redesign this visual needed a safety net *first*.
+- Rendering checks must be **deterministic** — cross-environment font rendering is the top cause of
+  screenshot flakiness, and the build already vendors fonts (no CDN, #24).
+- The PDF must stay a **clean linear document**; `src/utils/pdf.js` renders default print media and
+  should not need to change.
+- Any client-side motion must be **accessible** (reduced-motion, keyboard) and must not hide content
+  if JavaScript fails — the site is a static, no-backend build.
+
+## Decision
+
+**1. A visual-regression + PDF-render gate, built tests-first (US1).** `@playwright/test`
+`toHaveScreenshot({ fullPage: true })` snapshots `dist/index.html` at the six Bootstrap breakpoints
+(375/576/768/992/1200/1440) against committed baselines in `tests/__screenshots__/`; a second spec
+asserts the build produced a valid PDF. It is a **required PR check** (`.github/workflows/visual.yml`)
+and runs locally via `make visual` / `make visual-update`.
+
+- **Determinism:** the gate runs in a **pinned Playwright image**
+  (`mcr.microsoft.com/playwright:v1.61.1-noble`) — the same image locally and in CI — plus the
+  vendored fonts, `maxDiffPixelRatio` tolerance, `reducedMotion: 'reduce'`, and a test-only
+  `tests/snapshot.css` that forces scroll-reveal elements to their settled state and hides the daily
+  "Last update" date. Baselines are committed and updated as a **reviewed** step (`make visual-update`).
+
+**2. Screen/print decoupling driven by CSS media (US2).** One template + one stylesheet; the rich
+screen presentation (cards, sticky section nav) is confined to `@media (not print)`, and `@media print`
+flattens the cards, hides the nav, and reproduces the pre-redesign linear layout. `pdf.js` is
+unchanged (no `emulateMedia`). Skills keep their original grid markup (un-carded) because a Bootstrap
+`.row`'s gutters render differently inside a card box in print — keeping that structure identical
+guarantees the PDF's skills grid is byte-identical.
+
+**3. Accessible, fail-visible scroll-reveal (US3).** `src/assets/reveal.js` sets a `.js` root class
+(before first paint), then a one-shot `IntersectionObserver` reveals `.reveal` sections. Content is
+**visible by default**; only with `.js` set *and* `prefers-reduced-motion: no-preference` does it start
+hidden and ease in (opacity/transform only — no layout shift). It **fails visible**: no JS, no
+`IntersectionObserver`, or any setup error reveals everything; `@media print` forces it visible.
+
+## Alternatives considered
+
+- **No test gate (rely on manual PDF checks + lint).** Rejected: a visual redesign with no regression
+  net is exactly how a broken breakpoint or PDF ships unnoticed; the gate also delivered value against
+  the *current* page before any redesign landed.
+- **DOM diffing / a headless assertion library instead of pixel snapshots.** Rejected: the risk is
+  *visual* (overflow, layout, fonts), which pixel snapshots capture directly; DOM assertions miss it.
+- **A separate print template (or `emulateMedia` in `pdf.js`).** Rejected: two templates drift and the
+  build stays simpler with one source; a CSS media split keeps content parity by construction and
+  leaves `pdf.js` untouched.
+- **A CSS-only reveal (e.g. scroll-driven animations) or a heavier animation library.** Rejected:
+  scroll-driven CSS lacks the reduced-motion/no-JS safety and broad support we wanted; a library is
+  unnecessary weight for a subtle one-shot reveal.
+- **Cross-OS/browser snapshot matrix.** Rejected: a single pinned Linux image (matching CI) is
+  deterministic and cheap; a matrix multiplies flakiness and baselines for little value on a static
+  page.
+
+## Consequences
+
+- **Positive:** every PR is gated on how the page renders at all breakpoints *and* on the PDF still
+  building; intentional visual changes are explicit, reviewed baseline diffs. The screen can now evolve
+  boldly while the PDF stays safe — the decoupling is the platform for future screen-only interactivity.
+  The animation is accessible and degrades gracefully.
+- **Negative / trade-offs:** baselines are binary PNGs in git (they change whenever the design does —
+  a reviewed cost); the gate depends on the pinned Playwright image (bump deliberately); `break-inside:
+  avoid` on entries can leave whitespace when a long entry bumps to the next page (accepted — entries
+  are never split). This amends **constitution Principle IV** (v1.2.0 → 1.3.0): CI now has two gates
+  (lint + visual), not one.
+- **Follow-ups:** consider extending the gate's determinism notes if content grows; a bolder
+  gesture/deck screen experience is scoped as its own future initiative (the decoupling makes it safe).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ supersedes it and flip the old one's **Status** to `Superseded by ADR-XXXX`.
 
 - [0001 — Modernize the build runtime: Node 22 + Playwright](0001-modernize-build-runtime.md)
 - [0002 — Build in CI and deploy prebuilt to Vercel](0002-vercel-prebuilt-deploy.md)
+- [0003 — Visual-regression gate + screen/print decoupling for the CV redesign](0003-visual-regression-and-screen-print-decoupling.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,20 +14,27 @@ backend, database, or client-side framework — the page is plain HTML/CSS produ
 │   │   └── metadata.js           # CV content — the data model (see below)
 │   ├── templates/
 │   │   └── index.html            # Handlebars page template (Bootstrap 5 markup)
-│   ├── assets/                   # Copied verbatim into dist/: styles.css, photo.jpg,
+│   ├── assets/                   # Copied verbatim into dist/: styles.css, reveal.js, photo.jpg,
 │   │                             #   favicons, url-qr-code.svg
 │   └── utils/
 │       ├── pdf.js                # Playwright HTML → PDF renderer
 │       └── helpers/
 │           └── markdown.js       # Handlebars {{markdown}} helper
+├── tests/                        # Playwright visual-regression + PDF gate (see ci-cd.md)
+│   ├── visual.spec.js            #   fullPage snapshots at the 6 breakpoints
+│   ├── pdf.spec.js               #   asserts a valid PDF was built
+│   ├── snapshot.css              #   test-only styles for deterministic capture
+│   └── __screenshots__/          #   committed baseline PNGs
+├── playwright.config.js          # Test runner config (breakpoints, snapshot tolerance)
 ├── config/
 │   └── lint/super-linter.env     # Super-Linter configuration (see ci-cd.md)
 ├── vercel.json                   # Vercel serving config: prebuilt output + cache/security headers
 ├── Dockerfile                    # Builder image (node:22 + Playwright Chromium) for `make dev-build`
-├── Makefile                      # Dev, build, lint, and Vercel deploy commands
+├── Makefile                      # Dev, build, lint, visual, and Vercel deploy commands
 ├── package.json                  # npm scripts + dependencies
-└── .github/workflows/            # CI: Lint, Dev Container prebuild, Vercel Deploy
+└── .github/workflows/            # CI: Lint, Visual, Dev Container prebuild, Vercel Deploy
     ├── superlinter.yml
+    ├── visual.yml
     ├── devcontainer.yml
     └── deploy.yml
 ```
@@ -40,8 +47,8 @@ The whole build is `src/build.js`, run via `node src/build.js` (wrapped by `npm 
 `make page`). In order, it:
 
 1. **Empties `dist/`** — `fs.emptyDirSync(outputDir)` (`outputDir` = `<repo>/dist`).
-2. **Copies assets** — `src/assets/` → `dist/` verbatim (styles, photo, favicons, QR code), and
-   vendors Bootstrap / Font Awesome / Roboto (CSS + fonts) from pinned `node_modules` into
+2. **Copies assets** — `src/assets/` → `dist/` verbatim (styles, `reveal.js`, photo, favicons, QR
+   code), and vendors Bootstrap / Font Awesome / Roboto (CSS + fonts) from pinned `node_modules` into
    `dist/vendor/`, so the page and PDF need no CDN at build or render time (#24).
 3. **Registers the `markdown` helper** so templates can render Markdown content fields to HTML.
 4. **Compiles the template** — reads `src/templates/index.html`, compiles it with Handlebars, and
@@ -62,10 +69,14 @@ index.html ──┘                      ▲
                                 src/assets/ (copied into dist/)
 ```
 
-Because the PDF is rendered from the same HTML, the HTML and PDF versions stay consistent by
-construction. The CSS uses `screen` / `print` classes to vary output: the on-screen page shows a
-"Download PDF" link, while the print/PDF version shows a QR code to the site instead
-(`src/templates/index.html`).
+Because the PDF is rendered from the same HTML, the two versions stay consistent in **content** by
+construction, while their **presentation is decoupled via CSS media** (one template, one stylesheet —
+no separate print template, no `emulateMedia` call in `pdf.js`). On screen the CV is a rich,
+card/section-based layout with a sticky section nav and a subtle scroll-reveal; `@media print` flattens
+the cards back to a clean linear document, hides the nav, and disables the animation, so the PDF is
+unchanged by the redesign. The `screen` / `print` classes also swap the cross-links — the on-screen
+page shows a "Download PDF" link, the print/PDF version a QR code back to the site
+(`src/templates/index.html`, `src/assets/styles.css`).
 
 ## Content data model
 
@@ -98,13 +109,34 @@ Font Awesome `<i>` tags and `<a>` links.
 - `src/templates/index.html` is a Handlebars template producing a Bootstrap 5 single-page layout.
   Bootstrap 5.2, Font Awesome 6.1, and Roboto are **vendored** into `dist/vendor/` at build time
   (copied from pinned `node_modules`) and referenced locally — no CDN at runtime (#24).
-- Sections rendered: header (photo + name + facts + PDF/QR), About me, Skills (bar chart),
-  Professional Experience, Additional Experience, Robotics Competitions. Lists use Handlebars
-  `{{#each}}` over the arrays above.
-- `src/assets/styles.css` holds project-specific styling on top of Bootstrap, including the
-  `screen` / `print` visibility rules and the skill-bar styling.
+- Sections rendered: header (photo + name + facts + PDF/QR), then `<main>` with About me, Skills
+  (bar chart), Professional Experience, Additional Experience, Robotics Competitions — each a
+  `<section id>` (nav anchor). On screen, About and the three experience sections present their content
+  as Bootstrap **cards**, while Skills keeps its bare bar-chart grid (un-carded, so its PDF output is
+  byte-identical). Lists use Handlebars
+  `{{#each}}` over the arrays above; a screen-only sticky **section nav** (a `<details>` menu below
+  Bootstrap `md`, an inline list at `md+`) links to the section ids, with its link list defined once as
+  a Handlebars inline partial.
+- `src/assets/styles.css` holds project-specific styling on top of Bootstrap: the `screen` / `print`
+  visibility rules, the skill-bar styling, the card/section/nav layout, and the scroll-reveal. The
+  screen/print split is media-driven — `@media print` flattens the cards, hides the nav, and disables
+  motion so the PDF stays linear (Skills keeps its original grid markup, un-carded, so its print output
+  is byte-identical). See the [rendering contract](../specs/002-digital-cv-redesign/contracts/rendering-contract.md).
+- `src/assets/reveal.js` is a small progressive-enhancement script (loaded from `<head>`): it sets a
+  `.js` root class, then a one-shot `IntersectionObserver` reveals `.reveal` sections as they scroll
+  in. It **fails visible** — with no JS, no `IntersectionObserver`, or any error, all content stays
+  shown — and the reveal is disabled for reduced-motion users and in print.
 - Note: this template/repo originates from the [`sneas/cv-template`](https://github.com/sneas/cv-template)
   project.
+
+## Tests
+
+The one automated test suite is a **visual-regression + PDF-render gate** (Playwright), not a
+unit/integration suite — it protects how the site renders across breakpoints and that the PDF still
+builds. It lives in `tests/` (`visual.spec.js`, `pdf.spec.js`, `snapshot.css`, committed baselines in
+`__screenshots__/`) with `playwright.config.js` at the root, runs via `make visual` / `make
+visual-update`, and is a required PR check. See [ci-cd.md](ci-cd.md#visual--pdf-gate) for how it runs
+and how baselines are updated.
 
 ## Runtime & dependencies
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,15 +1,17 @@
 # CI/CD
 
-CI lints every change and prebuilds the Dev Container image. CD is automated: GitHub Actions builds
-the site and deploys the prebuilt output to **Vercel** on every push — production from `main`, a
-preview per PR — with Vercel-managed TLS. There is no manual server or certificate step.
+CI lints every change, runs a visual-regression + PDF-render gate, and prebuilds the Dev Container
+image. CD is automated: GitHub Actions builds the site and deploys the prebuilt output to **Vercel**
+on every push — production from `main`, a preview per PR — with Vercel-managed TLS. There is no
+manual server or certificate step.
 
 ## Continuous Integration — GitHub Actions
 
-Three workflows: **`.github/workflows/superlinter.yml`** (name: `Lint`) lints every change,
-**`.github/workflows/devcontainer.yml`** (name: `Dev Container`) prebuilds the Dev Container image
-(see [Dev Container image prebuild](#dev-container-image-prebuild)), and
-**`.github/workflows/deploy.yml`** (name: `Deploy`) builds and deploys the site to Vercel (push to
+Four workflows: **`.github/workflows/superlinter.yml`** (name: `Lint`) lints every change,
+**`.github/workflows/visual.yml`** (name: `Visual`) runs the visual-regression + PDF-render gate (see
+[Visual + PDF gate](#visual--pdf-gate)), **`.github/workflows/devcontainer.yml`** (name: `Dev
+Container`) prebuilds the Dev Container image (see [Dev Container image prebuild](#dev-container-image-prebuild)),
+and **`.github/workflows/deploy.yml`** (name: `Deploy`) builds and deploys the site to Vercel (push to
 `main` → production, `pull_request` → preview; see [Continuous Deployment](#continuous-deployment--vercel)).
 The lint workflow:
 
@@ -22,7 +24,8 @@ The lint workflow:
      (`permissions: statuses: write`, using the default `GITHUB_TOKEN`).
 - A Super-Linter status badge is shown at the top of the root [`README.md`](../README.md).
 
-There are **no automated tests** for the site — linting is the gate on site changes. Site build +
+Site changes are gated by **two** required checks: linting (above) and the **visual-regression +
+PDF-render** gate ([below](#visual--pdf-gate)) — there is no unit/integration suite. Site build +
 deploy runs in CI via the `Deploy` workflow ([below](#continuous-deployment--vercel)); the Dev
 Container workflow builds and smoke-tests the *dev-environment* image (not the site itself).
 
@@ -83,6 +86,37 @@ Caveats:
   against `main`. Local is broader, not narrower.
 - **Vercel:** the deploy-preview check runs on Vercel's side and is **not** covered by `make lint`;
   it can only be validated after pushing.
+
+### Visual + PDF gate
+
+`.github/workflows/visual.yml` (name: `Visual`, job `Visual + PDF checks`) is a **required PR check**
+that guards how the site renders. It runs in the **pinned Playwright image**
+(`mcr.microsoft.com/playwright:v1.61.1-noble`) — the same image `make visual` uses locally — so CI
+rendering matches the committed baselines exactly (cross-environment font rendering is the #1 snapshot
+flake).
+
+- **Triggers:** `push` to `main` and every `pull_request`.
+- **What it does:** `npm ci` → `npm run build` (the noble image ships no `make`) → `npx playwright
+  test`, running two specs, then uploads the Playwright HTML report + diff images as an artifact on
+  failure:
+  - `tests/visual.spec.js` — `toHaveScreenshot({ fullPage: true })` of `dist/index.html` at the six
+    Bootstrap breakpoints (375/576/768/992/1200/1440), diffed against `tests/__screenshots__/`.
+  - `tests/pdf.spec.js` — asserts the build produced a valid, non-empty `dist/*.pdf` (`%PDF-` header).
+- **Determinism:** baselines are committed and rendered in the pinned image; snapshots run with
+  `reducedMotion: 'reduce'` and a test-only `tests/snapshot.css` that forces scroll-reveal elements to
+  their settled state and hides the daily "Last update" date, so re-runs are stable.
+
+Run it locally (same result as CI):
+
+```sh
+make visual         # build + run the gate in the pinned Playwright image
+make visual-update  # regenerate the committed baselines after an *intentional* visual change
+```
+
+`make visual` is the authoritative check; `make visual-update` is a **reviewed** step — when a change
+deliberately alters the page, run it and commit the regenerated PNGs in the same PR (the baseline diff
+is the review surface). A missing or mismatched baseline fails the gate (CI never passes
+`--update-snapshots`).
 
 ### Dev Container image prebuild
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -71,6 +71,8 @@ Everything goes through the `Makefile` — run `make <target>`:
 | Build on the host (HTML + PDF) | `make page` | needs host Node + Playwright Chromium |
 | Fast lint (inner loop) | `make lint-fast` | native JS + Markdown; approximates CI |
 | Full lint (CI parity) | `make lint` | the Super-Linter image; the authoritative gate |
+| Visual + PDF gate | `make visual` | runs the Playwright snapshot + PDF check in the pinned image; a required PR check |
+| Update visual baselines | `make visual-update` | regenerates the committed snapshots after an *intentional* visual change (reviewed; commit the PNGs) |
 | Dockerized build (no local Node) | `make dev-build` | builds in Docker, copies output to `dist/` |
 
 > **Builds and PDF rendering run in the Dev Container (or CI), not the host.** The PDF is rendered


### PR DESCRIPTION
Final **Polish** phase of the digital CV redesign (spec `002-digital-cv-redesign`) — brings the harness docs in line with the shipped visual gate (US1), card/section redesign (US2), and scroll-reveal (US3). Docs-only; no code changes.

## Changes
- **Constitution** — amend **Principle IV → v1.3.0**: CI now has **two** gates (lint + visual-regression/PDF), replacing the old "there is no test suite… linting is the only gate."
- **AGENTS.md** — Testing Instructions now cover the visual + PDF gate, `make visual` / `make visual-update`, and the `tests/` suite.
- **docs/ci-cd.md** — new "Visual + PDF gate" section (workflow, determinism, local run); workflow count 3 → 4.
- **docs/architecture.md** — `tests/` suite, the screen/print decoupling, and `reveal.js`; directory layout updated.
- **docs/local-development.md** + **README.md** — `make visual` / `make visual-update` in the command lists.
- **ADR 0003** — records the visual-regression + screen/print-decoupling + accessible-animation decisions; indexed in the ADR README.

## Verification (T023)
- `make lint` green; `make visual` green (7 passed) on the merged redesign.
- All internal links/anchors resolve; constitution ↔ AGENTS.md consistent.
- Success criteria **SC-001…SC-007** confirmed (no-overflow across breakpoints, regression caught by the required gate, PDF unchanged, static build, local=CI).

## Self-review (`/code-review`)
An independent docs-accuracy pass verified every claim against the actual workflows/config/code and caught one internal contradiction (architecture.md described Skills as carded when it's intentionally un-carded) — fixed.

Closes #116
Closes #117
Closes #118
Closes #119
Closes #120
Closes #121
Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)