### PR TITLE
Add spec: interactive card rails (003)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/002-digital-cv-redesign"
+  "feature_directory": "specs/003-interactive-card-rails"
 }

--- a/specs/003-interactive-card-rails/checklists/requirements.md
+++ b/specs/003-interactive-card-rails/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Digital CV — interactive swipeable card rails
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Tech mentions (vanilla / no-framework, native snap-to-card scrolling) are **scope constraints and
+  documented assumptions** carried from the user's explicit non-goals — consistent with how 002's spec
+  recorded "Handlebars/Playwright retained." They bound scope rather than prescribe implementation.
+- No [NEEDS CLARIFICATION] markers: informed defaults are recorded in **Assumptions** (which sections
+  become rails; snap-with-peek behavior; signature form deferred to design). `/speckit-clarify` can
+  refine these before planning.

--- a/specs/003-interactive-card-rails/contracts/rail-interaction-contract.md
+++ b/specs/003-interactive-card-rails/contracts/rail-interaction-contract.md
@@ -1,0 +1,55 @@
+# Contract: card-rail interaction (screen vs. print)
+
+What a card rail MUST satisfy. Extends the 002 rendering contract (screen/print CSS decoupling); the
+rail layer is screen-only and flattens in print. Verified by the visual + PDF gate and by manual
+keyboard/screen-reader/no-JS checks.
+
+## Structure & semantics
+
+| Aspect | Requirement |
+|--------|-------------|
+| Container | Each rail is a **labelled, focusable, scrollable region**: `role="region"` (or `group`) + an accessible name (`aria-label`/`aria-labelledby`) + `tabindex="0"` on the scroll container (portable keyboard access — Safari/older engines don't focus scrollers natively). (D1, D2) |
+| List | Cards are a plain `<ul>`/`<li>` inside the container → SR announces an ordered, counted list. **No** `aria-roledescription`, tablist, or play/pause. (D1) |
+| Cards | One `<li>` per entry; the entry's real links/buttons remain the focus targets. Cards are **not** given `tabindex` unless the whole card is the interactive unit. Off-screen cards stay in the DOM and tab order. (D2) |
+
+## Screen (`@media screen`)
+
+| Aspect | Requirement |
+|--------|-------------|
+| Behavior | Horizontal **scroll-snap**: one focal card + a **peek** of the next, snapping between cards, at **every** breakpoint (no multi-card grid). `scroll-snap-type: x mandatory`; cards `scroll-snap-align: start` with a sub-100% basis + `min-width: 0`; `scroll-padding-inline` for the peek gutter. (D4, FR-001) |
+| Page overflow | The **page never scrolls horizontally** — only the rail's own track. `overscroll-behavior-x: contain` prevents scroll-chaining/ swipe-nav at the rail ends. (FR-003, SC-002, D4) |
+| Input | Operable by **touch (swipe), pointer, and keyboard**; a non-touch way to advance is available (arrow-scroll the focused region, and/or prev/next controls). (FR-002) |
+| Focus | Visible focus on the region and on card contents; `scroll-padding` + gutter + `outline-offset` keep focus rings from being clipped by the track (WCAG 2.4.7 / 2.4.11). (D2) |
+| Affordance | It is obvious the rail is swipeable and how much more exists: the **peek** + the **route-indicator** signature (position + count). A hidden scrollbar MUST be replaced by such an affordance. (FR-002, D4) |
+| Signature | A screen-only **"route between nodes"** position indicator: one node per card, active node in the `signal` accent; also the `aria-live` position target. (design.md, FR-008) |
+| Motion | Snapping always on; the animated smooth-scroll glide + node pulse gated behind `prefers-reduced-motion: no-preference`; JS scrolls branch on `matchMedia('(prefers-reduced-motion: reduce)')`. No layout shift. (D5, FR-009) |
+
+## Progressive enhancement (no JS)
+
+| Aspect | Requirement |
+|--------|-------------|
+| Baseline | With **no JavaScript**, each rail is a horizontally scrollable, snapping strip with **all cards present and reachable** (swipe / trackpad / keyboard). Nothing is hidden or requires a script to reveal. (FR-006, SC-003) |
+| JS layer | `src/assets/rails.js` is **additive only** — prev/next controls, the route indicator's interactivity, and an `aria-live` position status. It MUST NOT gate access to any card, and MUST fail visible (any error leaves content reachable). (D3) |
+
+## Print / PDF (`@media print`, via `page.pdf()`)
+
+| Aspect | Requirement |
+|--------|-------------|
+| Form | Rails **flatten** to the existing clean, linear entries — the container is not a scroller, cards stack linearly, `break-inside: avoid` per entry (as 002). |
+| Chrome | The route indicator, prev/next controls, scroll track, and all rail motion are **absent** in the PDF. |
+| Cross-link | Download-PDF (screen) and QR (print) intact. |
+| Generation | Produced by the **unchanged** `src/utils/pdf.js` (default print media, A4). **No `emulateMedia`**; the **PDF is byte-for-content unchanged** from 002 (same entries, order, layout). (FR-005, SC-004) |
+
+## Gate (visual-regression + PDF-render)
+
+| Aspect | Requirement |
+|--------|-------------|
+| Coverage | The rails' **deterministic resting state** is captured in the committed breakpoint baselines; the PDF-render check stays green. |
+| Determinism | Before asserting: `history.scrollRestoration = 'manual'`, reset each rail's `scrollLeft = 0`, disable smooth scroll, `await document.fonts.ready`, normalize the scrollbar; keep Playwright `animations:'disabled'`; allow a small `maxDiffPixelRatio` for subpixel snap jitter. Baselines generated in the pinned Playwright image, never the host. (D6) |
+| Review | Intentional visual changes update the committed baselines as a reviewed step (`make visual-update`); an unintended diff fails the gate. |
+
+## Invariants (carried from 002)
+
+- One template, one stylesheet; no separate print template; no `pdf.js` change; vendored fonts (no CDN).
+- Static-only (no backend/DB/API); the existing template engine retained (no framework). (FR-011)
+- Local dev, the build pipeline, and the Vercel deploy flow continue to work unchanged. (FR-012)

--- a/specs/003-interactive-card-rails/data-model.md
+++ b/specs/003-interactive-card-rails/data-model.md
@@ -1,0 +1,43 @@
+# Data model: interactive card rails
+
+No new data source or schema — CV content stays in `src/metadata/metadata.js` (unchanged, FR-010).
+This records how the **existing** content (already modelled for 002) maps to the rail presentation. It
+is a presentation model, not a persistence model.
+
+## Sections → rails (from `metadata.js`)
+
+| Section | Source key | Screen (002 → 003) | Print |
+|---------|-----------|--------------------|-------|
+| Header / identity | `name`, `title`, `facts`, photo | Hero (unchanged) + Download-PDF | identity + QR |
+| About | `about_me` | Intro card (unchanged) | linear paragraph |
+| Skills | `skills` | Bar grid (unchanged, un-carded) | linear list/bars |
+| **Professional experience** | `positions[]` | **Rail** of position cards | linear entries (`break-inside: avoid`) |
+| **Additional experience** | `experience[]` | **Rail** of entry cards | linear entries |
+| **Robotics competitions** | `competitions[]` | **Rail** of entry cards | linear entries |
+
+Only the three multi-entry, content-dense sections become rails (confirmed in clarify). Header, About,
+and Skills are unchanged from 002. An entry's existing shape is reused unchanged: `title`, `period`,
+`contents` (Markdown), `skills[]` (badges; omitted for competitions).
+
+## Derived presentation entities (screen-only)
+
+- **Rail**: a section's ordered set of entries presented as a horizontally scroll-snapping track. A
+  rail exists only for a non-empty dense section; a section with one entry renders as a single card
+  with **no** "more" affordance (edge case). Exposed as a labelled, focusable scrollable region
+  wrapping a `<ul>` of cards.
+- **Card**: one entry, the focal unit of a rail (one focal card + peek of the next at every
+  breakpoint). Same content as the 002 card; its interactive links remain the natural focus targets.
+- **Route node**: one marker per card in the rail's **route indicator** (the signature). Ordered;
+  exactly one is "active" (the snapped card), rendered in the `signal` accent. Derived from the card
+  count + current scroll position — no new data.
+
+## Invariants
+
+- **Content parity**: screen and PDF present the *same* entries in the same order; only presentation
+  (rail vs. linear, chrome, signature) differs (FR-005, SC-004).
+- **No content added**: no new fields, entities, or data source; the route nodes are derived from the
+  existing entry count/order (FR-010).
+- **Reachability**: every card/entry is reachable without JavaScript (a scrollable strip) and by
+  keyboard (SC-003, FR-006/FR-007) — nothing is derived state that hides content.
+- **Empty/'single' safety**: a removed or single entry must not leave a dangling rail, a broken route
+  indicator, or a misleading affordance.

--- a/specs/003-interactive-card-rails/design.md
+++ b/specs/003-interactive-card-rails/design.md
@@ -1,0 +1,109 @@
+# Design direction: interactive card rails
+
+Produced with the **frontend-design** methodology (design-lead pass): a compact token system + the one
+signature element, deliberately avoiding generic "AI-default" looks. Intent-level; exact values are
+finalized at implementation and locked by the visual gate.
+
+## Brief, grounded in the subject
+
+The subject is an **Engineering Manager in distributed systems / reactive architecture**, who built
+and led **dispatch/routing** platforms (Delivery Hero, Flink) and competed in **rescue robotics**. The
+page's job: a fast, credible, *memorable* impression for a recruiter (often on a phone). The design
+thesis is the subject's own world: **a system of nodes you route between.** Cards are nodes; moving
+through a rail is routing between them. That metaphor — not a templated portfolio shell — is where the
+distinctiveness comes from.
+
+## Token system
+
+### Color — reuse, don't repaint
+
+Keep the existing neutral base and the existing red; **no new hue** (keeps the PDF identical and spends
+boldness on the interaction, per Principle V + frontend-design's "one bold place").
+
+| Token | Value | Role |
+|-------|-------|------|
+| `ink` | `#000` | headings |
+| `body` | `#595959` / `#858585` | text (AA-safe for interactive, existing scale for prose) |
+| `surface` | `#fff` | cards |
+| `page` | `#fff` (unchanged from 002) | page background |
+| `line` | `var(--light-color)` `#D9D9D9` | hairlines, inactive route nodes |
+| `signal` | the existing skill-bar **red** | the **active/live** accent: filled route node, focus/affordance emphasis |
+
+The red already means "signal strength" in the skill bars; reusing it as the **live node** on the
+route unifies the page into one "signal" language instead of adding a competing accent.
+
+### Type — make Roboto work harder, add no font
+
+Roboto 400/500 stays (PDF + body). Screen gets a **deliberate scale**, not a new face:
+
+- **Hero**: larger, tighter display sizing of the existing name/title (already present) — the
+  characteristic opening.
+- **Section eyebrow**: a small uppercase, letter-spaced label above each rail section (e.g. the section
+  name as a "route" label). Justified because it labels a real, ordered region.
+- **Card title / period / badges**: existing treatment, tuned for the card's fixed footprint.
+
+### Layout — vertical page, horizontal rails
+
+The 002 vertical page + sticky section nav is kept. The three dense sections become rails:
+
+```text
+mobile (one focal card + peek)              desktop (same model, wider card + controls)
+┌─────────────────────────┐                ┌───────────────────────────────────────────┐
+│ [sticky section nav]     │                │ [sticky section nav]                        │
+│                          │                │                                             │
+│ EXPERIENCE  (eyebrow)    │                │ EXPERIENCE            (eyebrow)      ‹  ›    │  ← prev/next (JS)
+│ ┌───────────────┐┌──    │  ← rail track  │ ┌─────────────────────────┐┌──────         │
+│ │  focal card   ││ pe   │    (snap)      │ │      focal card         ││  peek…         │
+│ │               ││ ek   │                │ │                         ││                │
+│ └───────────────┘└──    │                │ └─────────────────────────┘└──────         │
+│  ◦──◦──●──◦──◦           │  ← SIGNATURE   │  ◦──◦──●──◦──◦──◦──◦    3 / 7               │
+│  route indicator         │    (route)     │  route indicator                            │
+│                          │                │                                             │
+│ (page keeps scrolling ↓) │                │ (page keeps scrolling ↓)                    │
+└─────────────────────────┘                └───────────────────────────────────────────┘
+```
+
+- One focal card + a peek of the next at **every** breakpoint (no multi-card grid) — confirmed in
+  clarify.
+- The rail scrolls in its own track; the **page never scrolls horizontally**.
+- Non-rail sections (header, About, Skills) are unchanged from 002.
+
+## The signature: "route between nodes"
+
+Below each rail, the position indicator is drawn as a **route**: one node per card, connected by a
+line, the current card's node filled in `signal` red (a subtle, reduced-motion-aware pulse on change).
+It reads as a dispatch route / a path across a distributed topology — the subject's domain.
+
+Why this is a *choice*, not a default (frontend-design critique):
+
+- **Content-true, not decorative**: a rail *is* an ordered sequence, so a position/route indicator
+  encodes something real (which card, how many, there's-more) — passing the "does this marker actually
+  belong?" test. Plain carousel dots would be the templated answer; framing them as a connected
+  **route with a live node** ties them to the brief.
+- **One bold thing, everything else quiet**: no new palette, no new font, no extra chrome — the route
+  indicator is the single memorable element; the rest stays disciplined (Chanel's "remove one
+  accessory").
+- **Doubles as function**: it *is* the accessible position affordance + the `aria-live` target + the
+  "there's more" cue the research calls for — decoration and utility are the same object.
+- **Avoids the AI-default clusters**: not cream+serif+terracotta, not black+acid-green, not
+  broadsheet-hairlines; the distinctiveness is structural (the routing metaphor), derived from the
+  subject.
+
+Screen-only: in `@media print` the route indicator and all rail chrome vanish; entries flatten to the
+existing linear list (PDF unchanged).
+
+## Quality floor (baked in, per frontend-design + the a11y research)
+
+- Responsive down to ~320px; the page never scrolls horizontally.
+- Visible keyboard focus; the rail is a focusable, labelled region; cards reachable in order.
+- `prefers-reduced-motion` respected (instant snap, no glide/pulse).
+- No layout shift from rails or the signature (CLS ≈ 0).
+- Works with no JS (rail = scrollable strip; the route indicator degrades to the native scrollbar/peek
+  as the "there's-more" cue).
+
+## Deferred to implementation
+
+Exact card dimensions/peek ratio per breakpoint, the eyebrow's precise treatment, the route
+indicator's exact node styling and pulse timing, and whether prev/next controls are icon buttons or
+the route nodes themselves are clickable — all decided during build against the visual gate, within
+the tokens and contract above.

--- a/specs/003-interactive-card-rails/plan.md
+++ b/specs/003-interactive-card-rails/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Digital CV — interactive swipeable card rails
+
+**Branch**: `003-interactive-card-rails` | **Date**: 2026-07-03 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/003-interactive-card-rails/spec.md`
+
+## Summary
+
+Turn the three content-dense sections (Professional Experience, Additional Experience, Robotics
+Competitions) into **horizontally swipeable card rails** on the screen, layered on the 002
+card/section page. Each rail shows one focal card with a peek of the next and snaps between cards. The
+implementation is **CSS-first** — native `scroll-snap` provides the swipe/peek/snap with **no
+JavaScript required** — wrapped in a **labelled, focusable, scrollable `region`** for accessibility;
+a small progressive-enhancement script adds affordances (prev/next, a position indicator) but never
+gates content. The whole rail layer is **screen-only** and flattens in `@media print` to the existing
+linear entries, so the **PDF is unchanged**. The distinctive **signature** is a "route between nodes"
+position indicator (the rail's cards as ordered nodes on a route, the active card the live node) —
+tying the interaction to the subject's distributed-systems / dispatch-routing domain. The existing
+visual + PDF gate guards it, with new deterministic baselines for the rails' resting state.
+
+## Technical Context
+
+**Language/Version**: Node 22 build (Handlebars templating); vanilla browser **JavaScript (ES2020+)**
+for the light progressive-enhancement layer; CSS (native scroll-snap).
+
+**Primary Dependencies**: existing only — Handlebars, Playwright (`playwright` + `@playwright/test`),
+Bootstrap 5, vendored Roboto + Font Awesome. **No new runtime dependency, no framework, no new font.**
+
+**Storage**: N/A — static site; CV content stays in `src/metadata/metadata.js` (unchanged).
+
+**Testing**: the existing Playwright **visual-regression + PDF-render gate** (`make visual` /
+`make visual-update`, `tests/`), extended with the rails' deterministic resting state.
+
+**Target Platform**: static site on Vercel; modern evergreen browsers, with graceful degradation for
+no-JS and for engines that don't make scroll containers keyboard-focusable natively (Safari,
+pre-132 Chromium) — handled with `tabindex="0"` + `role`/label on the container.
+
+**Project Type**: single static web project (no backend/frontend split).
+
+**Performance Goals**: main content visible < ~2.5s on mobile (SC-008); swipe uses native scroll
+(smooth 60fps); **no layout shift** from the rails or signature (CLS ≈ 0).
+
+**Constraints**: PDF unchanged (SC-004); the **page never scrolls horizontally** — only rails scroll
+in their own track (SC-002); accessible (keyboard-operable, SR-exposed list, visible focus, WCAG 2.2
+focus-not-obscured, reduced-motion) (SC-005); **all content reachable with no JS** (SC-003);
+deterministic snapshots; vanilla / no framework (FR-011).
+
+**Scale/Scope**: 3 sections become rails (~4–11 cards each); 1 signature element; ~1 small JS file +
+CSS + template changes + baseline updates. Content unchanged.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.* Checked against
+constitution **v1.3.0**.
+
+- **I. The Makefile is the interface** — ✅ Reuses `make page` / `make visual` / `make visual-update`
+  / `make lint`. No new workflow needed (the light JS asset is copied by the existing `src/assets`
+  copy, like `reveal.js`); no new target required.
+- **II. Self-review before done** — ✅ Each increment runs `/code-review` and is recorded before PR.
+- **III. Docs stay in sync** — ✅ Docs (architecture.md, the rendering contract, ci-cd if the gate
+  changes) updated in the same PRs / a polish pass; a follow-up ADR if the rail approach is a notable,
+  durable decision.
+- **IV. Validate locally; CI gates are the safety net** — ✅ Both gates apply; the visual + PDF gate is
+  **extended** to cover the rails' resting state. **No constitution amendment needed** (v1.3.0 already
+  recognizes the two gates — unlike 002, which had to amend Principle IV).
+- **V. Reproducible and minimal** — ✅ Vanilla, **no new dependency, no new vendored font**; the rail
+  is native CSS + a tiny JS enhancement. Snapshot determinism reuses the pinned Playwright image.
+- **VI. The harness is a living system** — ✅ Will surface any gap (e.g. gate mechanics for
+  scroll-state) rather than patch ad hoc.
+
+**Result: PASS — no violations.** Complexity Tracking below is intentionally empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-interactive-card-rails/
+├── plan.md              # This file
+├── research.md          # Phase 0 — technical + design decisions
+├── design.md            # Phase 0 — frontend-design token system + signature + wireframes
+├── data-model.md        # Phase 1 — presentation model (rails/cards/route indicator)
+├── quickstart.md        # Phase 1 — validation scenarios
+├── contracts/
+│   └── rail-interaction-contract.md   # Phase 1 — rail behavior, a11y, PE, print, gate
+└── tasks.md             # Phase 2 (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── templates/index.html     # Add rail markup (region + <ul> of cards) to the 3 dense sections;
+│                            #   reference the rails enhancement script (screen-only effect)
+├── assets/
+│   ├── styles.css           # Rail layout (scroll-snap + peek), a11y focus/scroll-padding, the
+│   │                        #   route-indicator signature; @media print flattens rails to linear
+│   └── rails.js             # NEW — progressive-enhancement: prev/next, position indicator,
+│                            #   reduced-motion-aware scrolling (additive; content works without it)
+└── metadata/metadata.js     # UNCHANGED (content)
+
+tests/
+├── visual.spec.js           # Extend: rails' deterministic resting state (reset scroll, fonts)
+├── snapshot.css             # Extend if needed for determinism (e.g. normalize scrollbar)
+└── __screenshots__/         # Regenerated baselines (reviewed) for the rail resting state
+```
+
+**Structure Decision**: Single static project, unchanged. The feature is additive CSS + one small
+vanilla JS asset + template edits, on top of the 002 layout — no new directories, dependencies, or
+build steps. `rails.js` follows the `reveal.js` precedent (screen-only progressive enhancement, copied
+verbatim by the existing `src/assets` → `dist/` step).
+
+## Complexity Tracking
+
+> No constitution violations — nothing to justify.

--- a/specs/003-interactive-card-rails/quickstart.md
+++ b/specs/003-interactive-card-rails/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: validating interactive card rails
+
+Runnable checks that prove the feature works end-to-end. Build in the Dev Container / pinned image (not
+the host), per the repo convention. See [spec.md](spec.md), [contracts/](contracts/rail-interaction-contract.md).
+
+## Prerequisites
+
+- The 003 worktree (`../cv-003-interactive-card-rails`), Docker (for `make visual` / the pinned image).
+- Build: `make page-container` (or `npm run build` in the pinned image) → `dist/index.html` + `dist/*.pdf`.
+
+## Scenario 1 — Rails render and swipe (US1)
+
+1. Open `dist/index.html`; resize across xs/sm/md/lg/xl/xxl.
+2. **Expect**: Professional Experience, Additional Experience, and Robotics Competitions each render as
+   a horizontal rail — one focal card + a peek of the next — that snaps between cards on swipe/drag.
+   Header, About, Skills unchanged. The **page never scrolls horizontally** at any width.
+
+## Scenario 2 — Desktop / pointer + keyboard (US1, US2)
+
+1. On a desktop viewport, Tab to a rail; use arrow keys (and any prev/next control) to move through
+   cards; Tab into a card's links.
+2. **Expect**: the rail region is focusable with a visible focus ring; cards advance; the focused
+   card/links are never clipped by the track; a position/route indicator shows where you are and that
+   more cards exist.
+
+## Scenario 3 — Screen reader (US2)
+
+1. With a screen reader, navigate into a rail.
+2. **Expect**: it's announced as a labelled region containing a list of N cards; you can move through
+   them in order; position changes are announced (`aria-live`). No "carousel/slide/tab" mislabeling.
+
+## Scenario 4 — No JavaScript (US2, SC-003)
+
+1. Disable JavaScript; reload `dist/index.html`.
+2. **Expect**: every rail is still a horizontally scrollable strip; **all** cards/entries are reachable
+   (swipe/trackpad/keyboard) and readable; nothing is hidden; the page still works.
+
+## Scenario 5 — Reduced motion (US2)
+
+1. Enable "reduce motion" at the OS level; interact with a rail and the nav.
+2. **Expect**: snapping still works (instant, no glide); no node pulse or non-essential animation; the
+   rail stays fully functional.
+
+## Scenario 6 — PDF unchanged (US1, SC-004)
+
+1. Open `dist/<name>.<title>.pdf` (and diff against a pre-003 build).
+2. **Expect**: same sections and entries in the same **linear** order; **no** rail chrome, route
+   indicator, or controls; `break-inside: avoid` per entry; QR + "Online at" present. Byte-for-content
+   unchanged from 002.
+
+## Scenario 7 — The gate catches regressions (US1, SC-006)
+
+1. Run `make visual` → all breakpoints + the PDF check pass against the committed baselines.
+2. Introduce a deliberate regression (e.g. remove `min-width: 0` so a rail overflows the page, or break
+   the PDF) → `make visual` fails and reports the diff/failure.
+3. Revert → green. For an *intentional* rail visual change, `make visual-update` regenerates the
+   baselines (reviewed; commit the PNGs).
+
+## Scenario 8 — Signature & polish (US3)
+
+1. On screen, observe the "route between nodes" indicator under each rail as you move through cards.
+2. **Expect**: one distinctive, on-brand signature; active node in the signal accent; reduced-motion
+   respected; absent in the PDF; no layout shift.
+
+## Success-criteria map
+
+| Scenario | Criteria |
+|----------|----------|
+| 1, 2 | SC-001, SC-002 |
+| 3, 5 | SC-005 |
+| 4 | SC-003 |
+| 6 | SC-004 |
+| 7 | SC-006, SC-007 |
+| 8 | SC-008 (no layout shift) |

--- a/specs/003-interactive-card-rails/research.md
+++ b/specs/003-interactive-card-rails/research.md
@@ -1,0 +1,126 @@
+# Research: interactive swipeable card rails
+
+Phase 0 decisions. Grounded in the WAI-ARIA APG, MDN, web.dev, Playwright docs, and a11y practitioners
+(Adrian Roselli, Sara Soueidan, Ahmad Shadeed). Each: **Decision / Rationale / Alternatives**.
+
+## D1 — Rail semantics: labelled scrollable region + list (not the APG carousel widget)
+
+- **Decision**: Build each rail as a **labelled, focusable, scrollable `region`** (`role="region"` +
+  `aria-label`, or `role="group"`) wrapping a plain `<ul>`/`<li>` of cards. No `aria-roledescription`,
+  no tablist slide-picker, no play/pause.
+- **Rationale**: The APG "carousel" pattern targets **auto-rotating, JS-driven slideshows** with
+  scripted controls; a no-JS scroll-snap strip has all cards present and user-scrollable, so
+  carousel/slide/tab roles would mislabel it and imply behaviors it lacks. A region + `<ul>` exposes
+  what it is — a named area containing a countable, ordered list (SR announces "list, N items" +
+  position). `aria-roledescription` has patchy AT/localization support.
+- **Alternatives**: Full APG carousel (overkill, mislabels a static rail); native CSS Carousels
+  (`::scroll-marker`/`::scroll-button()`) — Chromium-only (135+), documented ARIA defects for
+  multi-item rails → **enhancement only, never baseline**.
+
+## D2 — Keyboard focus: `tabindex="0"` on the scroll container; don't tabindex cards
+
+- **Decision**: Put `tabindex="0"` + `role`/`aria-label` on the **scroll container** so keyboard users
+  can Tab to it and arrow-scroll in every browser. Do **not** add `tabindex` to cards — rely on the
+  real links inside them; keep off-screen cards in normal flow and the tab order. Add
+  `scroll-padding` so a focused/snapped card lands inside the track and its focus ring isn't clipped.
+- **Rationale**: A scroll container is **not** universally keyboard-focusable — Chromium only added
+  auto-focusable scrollers in 132 (2025), and **Safari/WebKit still doesn't** — so an explicit
+  `tabindex="0"` is the portable fix. A focusable element needs a name+role (WCAG 4.1.2), hence the
+  region+label. Bare `tabindex` on cards adds nameless focus stops; real links are already correctly
+  in the tab order. `overflow` can clip an edge card's focus ring (WCAG 2.4.7 / 2.4.11), which
+  `scroll-padding` + gutter + `outline-offset` fix.
+- **Alternatives**: Rely on Chromium auto-focusable scrollers (not portable — Safari); `tabindex="-1"`
+  on cards (useless with no JS to move focus); `inert` off-screen cards via `scroll-state()` (Chromium
+  only, and Chrome warns it breaks SR item counts for list rails).
+
+## D3 — Progressive enhancement: CSS-only baseline, JS additive-only
+
+- **Decision**: The no-JS baseline is a horizontally scrollable, snapping strip with **all cards in the
+  DOM and reachable** (swipe / trackpad / keyboard). `src/assets/rails.js` adds only *affordances* —
+  prev/next controls, the position/route indicator, and an `aria-live` position status — layered on
+  top. Content is **never** hidden behind JS.
+- **Rationale**: Snap + overflow are pure CSS (web.dev/MDN); content is plain HTML. Mirrors the 002
+  `reveal.js` "fail visible" principle: JS improves ergonomics, never gates access.
+- **Alternatives**: JS-mounted carousel (content vanishes without JS — rejected); native CSS
+  marker/button controls (Chromium-only — use as an optional extra, not the affordance baseline).
+
+## D4 — Peek + snap mechanics (CSS)
+
+- **Decision**: Container: `overflow-x: auto; scroll-snap-type: x mandatory; scroll-padding-inline:
+  <gutter>; overscroll-behavior-x: contain`. Cards: `flex: 0 0 clamp(<min>, <sub-100%>, <max>);
+  min-width: 0; scroll-snap-align: start`. Keep a (thin) scrollbar or provide an equivalent
+  "there's-more" affordance (the peek + route indicator serve this). Use **logical** properties
+  (`scroll-padding-inline`, `inline` axis) for RTL-safety.
+- **Rationale**: `scroll-snap-type: x mandatory` + `scroll-snap-align` is the canonical mechanism;
+  `mandatory` suits per-card snapping. A sub-100% card basis makes the next card **peek**;
+  `scroll-padding-inline` turns the remainder into a stable gutter. `min-width: 0` is essential — the
+  default `min-width: auto` refuses to shrink and would overflow the **page** (violating SC-002).
+  `overscroll-behavior-x: contain` stops scroll-chaining to the page / swipe-nav at the rail ends.
+- **Alternatives**: `proximity` snap (softer; better only for cards taller than the viewport — keep
+  `mandatory` here but see edge cases); `scroll-snap-align: center` (symmetric peeks — `start` chosen
+  for a left-aligned rail with one trailing peek); hiding the scrollbar with no replacement (rejected —
+  removes an affordance/operability, WCAG 2.1.1).
+
+## D5 — Reduced motion: keep snapping, gate only the smooth glide
+
+- **Decision**: Snapping stays on always; gate only the animated smooth-scroll glide behind
+  `@media (prefers-reduced-motion: no-preference) { html { scroll-behavior: smooth } }`. Any
+  JS-driven prev/next scroll MUST branch on `matchMedia('(prefers-reduced-motion: reduce)')` (an
+  explicit `behavior:'smooth'` in `scrollTo` overrides CSS and ignores the preference).
+- **Rationale**: Snapping is a resting-position behavior, not animation; the motion to suppress is the
+  glide. Instant-as-fallback (the `no-preference` gate) means older/unmatched UAs get the safe
+  behavior. WCAG 2.3.3.
+- **Alternatives**: Disabling `scroll-snap-type` under reduced-motion (wrong — kills a useful,
+  non-animated behavior); inverse `@media (reduce)` form (works, but `no-preference` gating makes the
+  accessible path the default).
+
+## D6 — Deterministic snapshots for the gate
+
+- **Decision**: In the visual spec, before asserting a rail: set `history.scrollRestoration =
+  'manual'`, reset the rail's `scrollLeft = 0` (or `scrollIntoView({behavior:'instant'})` a chosen
+  card), disable smooth scroll, `await document.fonts.ready`, and normalize the scrollbar consistently.
+  Keep Playwright defaults (`animations:'disabled'`, `caret:'hide'`) and allow a small
+  `maxDiffPixelRatio`/`threshold` for subpixel snap jitter. Generate baselines in the **pinned
+  Playwright image** (as today), never the host.
+- **Rationale**: Snap containers re-snap to the previously snapped element and `scrollRestoration`
+  defaults to `auto`; a screenshot mid-smooth-scroll catches a between-snap frame; `animations:
+  'disabled'` does **not** cover scrolling. Subpixel snap positions cause 1px edge diffs, absorbed by
+  tolerance. Matches this repo's container-first determinism (002).
+- **Alternatives**: `stylePath` masking of volatile bits (already used via `tests/snapshot.css` — extend
+  if needed); snapshot the rail element rather than full page (keep full-page for consistency with 002,
+  add per-rail only if jitter demands).
+
+## D7 — Design accent & type discipline (frontend-design pass — see design.md)
+
+- **Decision**: **No new color and no new font.** Keep the neutral base (ink/gray/white) and reuse the
+  existing skill-bar **red as the single "signal/active" accent**; spend the boldness on the
+  interaction/**signature form**, not a new palette. Keep Roboto (PDF + body) with a stronger,
+  intentional screen type scale rather than adding a display face.
+- **Rationale**: frontend-design's "spend boldness in one place" + constitution Principle V (minimal,
+  pin what determines output). A new color/font would touch the PDF or add vendored weight for little
+  gain; the routing signature carries the personality. Avoids the generic AI-default palettes.
+- **Alternatives**: A second accent (indigo) for the route signature (rejected — two accents clutter,
+  the reused red already reads as "the live signal"); a screen-only display face (rejected — extra
+  vendored font, more baseline churn; Roboto at a deliberate scale suffices).
+
+## D8 — The signature: "route between nodes" (justified sequence indicator)
+
+- **Decision**: The distinctive moment is each rail's **position/progress rendered as a route between
+  nodes** — the cards as ordered nodes on a connected route line, the active card the filled "live"
+  (red) node — doubling as the rail's position affordance and `aria-live` target.
+- **Rationale**: frontend-design says structural devices (numbering/markers) must encode something
+  *true*: a rail **is** an ordered sequence, so a position/route indicator is content-justified (not
+  decorative). It ties directly to the subject's distributed-systems / dispatch-routing domain,
+  concentrates the boldness in one memorable element, and solves the a11y "where am I / there's more"
+  need. Screen-only (absent in the PDF).
+- **Alternatives**: Plain carousel dots (generic, fails the "is this a choice for *this* brief" test);
+  a full-screen hero deck (rejected earlier — Direction B chosen); numbering without the route line
+  (loses the domain metaphor).
+
+## Meta-note (from research)
+
+Practitioners (Roselli) caution that users pattern-match horizontal rails to "marketing carousels" and
+skip them. Our mitigations directly address this: the **sticky section nav still jumps to sections**
+(rails aren't the only way to content), the **route indicator makes position + "there's more"
+explicit**, and content is never hidden. Keep a deliberate "does this section benefit from a rail?"
+check — hence rails are limited to the three genuinely multi-entry, content-dense sections.

--- a/specs/003-interactive-card-rails/spec.md
+++ b/specs/003-interactive-card-rails/spec.md
@@ -1,0 +1,232 @@
+# Feature Specification: Digital CV — interactive swipeable card rails
+
+**Feature Branch**: `003-interactive-card-rails`
+
+**Created**: 2026-07-03
+
+**Status**: Draft
+
+**Input**: User description: "Make the digital CV more interactive and engaging by presenting
+content-dense sections as horizontally swipeable, accessible card rails, layered on the existing
+responsive vertical page — without changing the PDF. Builds on the 002 redesign (card/section layout,
+sticky section nav, scroll-reveal, screen/print CSS decoupling, and a visual-regression + PDF-render
+test gate). Stay vanilla (HTML/CSS + light progressive-enhancement JS, CSS scroll-snap); no framework
+migration; content unchanged; static, no backend; the PDF stays a clean linear document; accessible
+and progressive-enhancement-safe; the existing test gate keeps guarding it."
+
+## Clarifications
+
+### Session 2026-07-03
+
+- Q: Which sections become swipeable card rails? → A: The three content-dense, multi-entry sections —
+  Professional Experience, Additional Experience, Robotics Competitions. Skills (bar grid, kept
+  un-carded for PDF fidelity) and About (single card) stay as-is.
+- Q: How should a rail advance between cards? → A: Snap-with-peek — free swipe/scroll that snaps to a
+  card, always showing a peek of the next (native scroll-snap; the no-JS fallback is a plain scrollable
+  strip). Not a strict one-card pager.
+- Q: On wide desktop screens, how many cards should a rail show? → A: One focal card at a time with a
+  peek of the next (same feel as mobile; the rail scrolls) — rails do not expand into a multi-card grid.
+- Q: The distinctive "signature" moment — decide now or at design? → A: Defer the concrete form to
+  `/speckit-plan` (with the frontend-design skill); the spec keeps it intent-level.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Swipe through content-dense sections as card rails (Priority: P1)
+
+As a visitor (often a recruiter on a phone), I want the long, content-dense sections of the CV
+(Professional Experience, Additional Experience, Robotics Competitions) presented as **horizontally
+swipeable card rails** — where I flick/drag through entries one at a time with a peek of the next
+card — so I can browse those sections quickly and engagingly instead of scrolling a long vertical
+page.
+
+**Why this priority**: This is the core user-facing improvement and the whole reason for the
+initiative — turning long stacked sections into a compact, interactive, app-like browsing experience.
+It delivers the headline value on its own.
+
+**Independent Test**: Load the page on a phone, tablet, and desktop → each content-dense section is a
+horizontal rail; the visitor can move through its cards (swipe on touch, and via pointer and keyboard
+on desktop) with a peek of the adjacent card; the surrounding vertical page and the sticky section nav
+still work; the page never scrolls horizontally as a whole; and the generated PDF is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** the digital page on a touch device, **When** the visitor swipes horizontally on a
+   content-dense section, **Then** the section's cards move one at a time and settle (snap) on a card,
+   showing a peek of the next.
+2. **Given** the digital page on a desktop (no touch), **When** the visitor uses the on-screen
+   controls, pointer, or keyboard, **Then** they can move through the same rail's cards, with a clear
+   indication of position and more cards available.
+3. **Given** any target breakpoint, **When** the page renders, **Then** the **page itself never
+   scrolls horizontally** — only the rails scroll within their own track — and every card's content is
+   reachable and legible.
+4. **Given** the redesigned page, **When** the PDF is generated from the same build, **Then** the PDF
+   is **unchanged** — the rails flatten to the existing clean, linear entries, with no interactive
+   chrome, and the Download-PDF and QR cross-links intact.
+
+---
+
+### User Story 2 - Accessible and works without JavaScript (Priority: P2)
+
+As a keyboard or screen-reader user — or any visitor whose JavaScript doesn't run, or who prefers
+reduced motion — I want the card rails to be fully usable and to never hide content behind a gesture,
+so the CV is complete and navigable for everyone.
+
+**Why this priority**: Accessibility and graceful degradation are core quality bars for a public CV;
+an interaction that only works for touch/mouse users, or that hides content when JS fails, is not
+acceptable. It is separable from P1 (P1 delivers the interaction; P2 guarantees it's usable by all).
+
+**Independent Test**: With a keyboard only, tab/arrow through a rail's cards with a visible focus
+indicator; with a screen reader, the rail is announced as a list of cards; with JavaScript disabled,
+each rail is still a horizontally scrollable container and **all** content is reachable; with "reduce
+motion" enabled, no non-essential motion plays. In every case no content is trapped or hidden.
+
+**Acceptance Scenarios**:
+
+1. **Given** a keyboard-only visitor, **When** they navigate a rail, **Then** each card is reachable
+   with a visible focus indicator and standard key interactions move between cards.
+2. **Given** a screen-reader user, **When** they reach a rail, **Then** it is exposed as a labelled
+   list of cards they can move through in order.
+3. **Given** a visitor with JavaScript disabled (or before scripts run), **When** they view a
+   content-dense section, **Then** it remains a horizontally scrollable strip and all cards/content are
+   reachable — nothing is left hidden or requires a script to reveal.
+4. **Given** a visitor who prefers reduced motion, **When** they interact with a rail, **Then**
+   non-essential animation is disabled while the rail stays fully functional.
+
+---
+
+### User Story 3 - A distinctive signature moment & rail polish (Priority: P3)
+
+As a visitor, I want the page to have one distinctive, memorable interactive moment and tasteful
+polish on the rails (clear affordances, gentle emphasis of the focused card), so the CV feels
+crafted and modern rather than generic — without distraction or hurting performance/accessibility.
+
+**Why this priority**: A finishing enhancement layered on the P1 rails; it raises the impression from
+"functional" to "memorable" but is not required for a usable, navigable interactive CV.
+
+**Independent Test**: On screen, the signature moment is present and works across breakpoints and input
+types, the rails show clear affordances (position/there's-more) and subtle focused-card emphasis, all
+reduced-motion-aware and layout-shift-free; in the PDF, none of it appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor with default settings, **When** they arrive and interact, **Then** one
+   distinctive signature moment makes the page memorable while the rest stays disciplined.
+2. **Given** any rail, **When** it is shown, **Then** affordances make it obvious that it is swipeable
+   and how much more content there is (position indication + peek), with subtle emphasis on the
+   focused card.
+3. **Given** the reduced-motion preference or the PDF output, **When** the page/PDF renders, **Then**
+   the signature/polish adds no motion (screen) and does not appear at all (PDF).
+
+---
+
+### Edge Cases
+
+- **Single-card / short sections**: a section with only one entry shows no misleading "more" affordance
+  and does not present an empty or broken rail.
+- **Very long card content**: a single entry longer than the viewport stays fully readable (its own
+  content scrolls or the card sizes to fit) without breaking the rail or overflowing the page.
+- **Very small screens (~320px)**: rails and cards stay legible with the page never scrolling
+  horizontally as a whole.
+- **No JavaScript / progressive enhancement**: rails remain horizontally scrollable strips with all
+  content reachable; the page is never left in a state that needs a script to show content.
+- **Print / PDF isolation**: rail chrome (scroll tracks, controls, position indicators, the signature
+  moment, animation) must not leak into the PDF, which stays a clean linear document.
+- **Reduced-motion / accessibility**: swipe/scroll still works; non-essential motion is suppressed; the
+  page stays keyboard-navigable with visible focus.
+- **Content edits**: adding/removing an entry in the content file must not break a rail, its
+  affordances, or the rendering checks.
+- **Intentional vs. accidental visual change**: because the check is visual-regression, the rails'
+  deterministic **resting state** is captured in the committed baselines; a deliberate change updates
+  them (reviewed), while an unintended visual diff fails the check.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The digital (screen) CV MUST present the content-dense sections (Professional Experience,
+  Additional Experience, Robotics Competitions) as **horizontally swipeable card rails** — one card
+  advanced at a time, settling (snapping) on a card, with a **peek** of the adjacent card. This
+  single-focal-card-with-peek presentation applies at **every breakpoint, including wide desktop** —
+  rails do not expand into a multi-card grid.
+- **FR-002**: Each rail MUST be operable by **touch (swipe/drag), pointer, and keyboard**, and MUST
+  show its **position and that more cards exist** (e.g. peek + a position indicator/controls). On
+  devices without touch, an equivalent non-touch way to advance MUST be available.
+- **FR-003**: The **page itself MUST never scroll horizontally** at any target breakpoint — only the
+  rails scroll within their own track — and every card and its content MUST remain reachable and
+  legible.
+- **FR-004**: The existing **vertical page structure and the sticky section navigation MUST be kept**;
+  the sticky nav still jumps to each section, and non-rail sections (header, About, Skills) are
+  unchanged.
+- **FR-005**: The rails and all interactive chrome MUST be **screen-only**; in print/PDF they flatten
+  to the existing **clean, linear entries** (extending the 002 screen/print decoupling). The **PDF MUST
+  remain unchanged** in content, order, and form, and its generation MUST NOT be complicated (no change
+  to the PDF renderer).
+- **FR-006**: The CV MUST remain **usable with no JavaScript** — each rail degrades to a horizontally
+  scrollable strip with **all content reachable**; content MUST NEVER be hidden behind a gesture or
+  require a script to be revealed (progressive enhancement).
+- **FR-007**: The rails MUST be **accessible** — keyboard-navigable with a visible focus indicator,
+  exposed to assistive tech as a labelled list of cards, sufficient contrast, and respectful of the
+  **reduced-motion** preference.
+- **FR-008**: The page MUST include **one distinctive "signature" interactive moment** that makes it
+  memorable, while the rest of the interface stays disciplined; its concrete form is chosen at design
+  time.
+- **FR-009**: Motion (snap feedback, focused-card emphasis, the signature moment) MUST be **subtle,
+  reduced-motion-aware, and cause no layout shift**.
+- **FR-010**: CV **content is unchanged** — it remains sourced from the existing content data file;
+  this feature changes presentation and interaction, not content.
+- **FR-011**: The site MUST remain a **static build** with **no backend, database, or API**; any
+  interactivity is client-side only, and it stays on the **existing template engine (no framework
+  migration)**.
+- **FR-012**: The existing automated **visual-regression + PDF-render gate MUST keep guarding the
+  page**: the rails' deterministic resting state is captured in the committed baselines, the PDF check
+  stays green, and the checks remain runnable locally with the same result as CI. Local development, the
+  build pipeline, and the deploy flow MUST remain intact.
+
+### Key Entities *(include if feature involves data)*
+
+- **Content sections & entries**: the existing content groups from the content data file — the
+  content-dense ones (`positions`, `experience`, `competitions`) provide the **entries** that become
+  the **cards** within each section's **rail**; header, About, and Skills are unchanged. No new content,
+  fields, or data source is introduced (this is a presentation/interaction model over the 002 model).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a phone, a visitor can move through the entries of a content-dense section by swiping,
+  reaching any entry in that section in **under ~5 seconds**, without scrolling the whole page.
+- **SC-002**: Across **all target breakpoints (xs/sm/md/lg/xl/xxl)** the **page never scrolls
+  horizontally**, every rail's cards are reachable, and every major section stays visible and legible
+  (verified by the visual-regression check).
+- **SC-003**: With **JavaScript disabled**, **100%** of the CV content remains reachable and readable
+  (no card or entry is hidden or requires a script to reveal).
+- **SC-004**: The generated **PDF is unchanged** by this feature — same sections and entries in the
+  same linear order, no interactive/rail chrome, Download-PDF and QR cross-links intact.
+- **SC-005**: The rails are **fully keyboard-operable** (every card reachable with visible focus) and
+  expose their cards to assistive tech as a navigable list; reduced-motion users get no non-essential
+  motion.
+- **SC-006**: A responsive regression (page horizontal overflow, a hidden/broken rail), an unintended
+  visual change, or a PDF-render failure is caught by the gate **100% of the time** and blocks the PR.
+- **SC-007**: The site still deploys as a **static** artifact (no backend/DB/API), on the existing
+  build/deploy flow, and contributors can reproduce the CI rendering result locally.
+- **SC-008**: Interacting with a rail causes **no visible layout shift**, and the page's main content
+  is visible on a typical mobile connection in **under ~2.5 seconds**.
+
+## Assumptions
+
+- **Which sections become rails** (confirmed): the three content-dense, multi-entry sections —
+  Professional Experience, Additional Experience, Robotics Competitions. Header, About (single card),
+  and Skills (bar grid, kept un-carded for PDF fidelity) are **not** rails.
+- **Rail behavior** (confirmed): free horizontal swipe/scroll that **snaps** to cards with a peek of
+  the next (native scroll-snap), not a strict one-card-per-action pager; one focal card with a peek at
+  every breakpoint (no multi-card grid on desktop). Desktop gets an equivalent non-touch affordance.
+- **Signature moment**: intentionally left to design (`/speckit-plan`, using the frontend-design
+  skill); a seed idea is a "distributed-systems / routing-between-nodes" motif that fits the subject,
+  but the spec only requires *one distinctive, accessible, screen-only signature*.
+- **Foundation reused**: the 002 screen/print CSS decoupling, sticky section nav, vendored fonts, and
+  the visual-regression + PDF-render gate are the base; this feature extends them (e.g. new baselines
+  for the rails' resting state) rather than replacing them.
+- **Vanilla + progressive enhancement**: implemented with HTML/CSS + light client-side JavaScript
+  (CSS scroll-snap for the rails); the existing template engine is retained; no framework, no backend.
+- **Primary audience**: a recruiter on a phone for the digital experience; the PDF serves formal/
+  offline sharing and is deliberately kept identical.

--- a/specs/003-interactive-card-rails/tasks.md
+++ b/specs/003-interactive-card-rails/tasks.md
@@ -1,0 +1,146 @@
+# Tasks: Digital CV — interactive swipeable card rails
+
+**Input**: Design documents from `specs/003-interactive-card-rails/`
+
+**Prerequisites**: plan.md, spec.md, research.md, design.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: This feature is guarded by the existing visual-regression + PDF-render gate (from 002), so
+gate/baseline tasks are first-class and explicitly in scope; there is no separate unit suite.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, and Polish tasks carry no story label)
+
+**Organization**: US1 is a complete CSS-only, accessible, PDF-safe rail (the MVP). US2 adds the
+progressive-enhancement JS affordances + rigorous a11y/no-JS verification. US3 adds the signature +
+polish. Each US2/US3 change ships with a reviewed baseline update.
+
+## Phase 1: Setup
+
+No standalone setup — reuses the 002 tooling (the Playwright gate, `@playwright/test`, `make visual` /
+`make visual-update`, the pinned image). No new dependency, framework, or vendored font (plan.md,
+Principle V).
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+- [T001](https://github.com/brunogbv/cv/issues/135) Extend the rail snapshot **determinism** harness so rail resting state is stable: in
+      `tests/visual.spec.js` set `history.scrollRestoration = 'manual'`, reset each rail's
+      `scrollLeft = 0`, and disable smooth scroll before capture; normalize the scrollbar in
+      `tests/snapshot.css`. Allow a small `maxDiffPixelRatio` in `playwright.config.js` if needed
+      (research D6, contract "Gate"). Blocks US1 baselines.
+
+## Phase 3: User Story 1 — Swipeable card rails (Priority: P1) 🎯 MVP
+
+**Goal**: The three dense sections are horizontally swipeable, snapping, one-focal-card-with-peek
+rails; keyboard-scrollable; the page never overflows horizontally; the PDF is unchanged. CSS-only —
+fully functional with no JavaScript.
+
+**Independent test**: quickstart Scenarios 1, 6, 7 — rails swipe/snap across breakpoints with no page
+overflow; the PDF is unchanged; the gate is green.
+
+- [T002](https://github.com/brunogbv/cv/issues/136) [US1] Restructure the three dense sections in `src/templates/index.html`: wrap each
+      section's entries in a focusable, labelled scrollable region (`role="region"` + `aria-label` +
+      `tabindex="0"`) containing a `<ul>` of card `<li>`s (data-model.md, contract "Structure").
+      Header, About, and Skills stay unchanged.
+- [T003](https://github.com/brunogbv/cv/issues/137) [US1] Add screen rail layout to `src/assets/styles.css`: `scroll-snap-type: x mandatory`;
+      cards `flex: 0 0 clamp(min, sub-100%, max)` + `min-width: 0` + `scroll-snap-align: start`;
+      `scroll-padding-inline` peek gutter; `overscroll-behavior-x: contain`. The **page must never
+      scroll horizontally** (research D4, contract "Screen", SC-002).
+- [T004](https://github.com/brunogbv/cv/issues/138) [US1] Add focus handling in `src/assets/styles.css`: visible focus on the region and card
+      links; `scroll-padding` + `outline-offset` so focus rings are not clipped by the track
+      (research D2; WCAG 2.4.7 / 2.4.11).
+- [T005](https://github.com/brunogbv/cv/issues/139) [US1] Extend `@media print` in `src/assets/styles.css`: rails **flatten** — region is not a
+      scroller, cards stack linearly, `break-inside: avoid` per entry, no rail chrome (contract
+      "Print"). No change to `src/utils/pdf.js`.
+- [T006](https://github.com/brunogbv/cv/issues/140) [US1] Gate the smooth-scroll glide behind `@media (prefers-reduced-motion: no-preference)`
+      in `src/assets/styles.css` (CSS-only for US1; snapping stays always-on) (research D5).
+- [T007](https://github.com/brunogbv/cv/issues/141) [US1] Regenerate the committed baselines (`make visual-update`) for the rails' resting
+      state; confirm `make visual` is green across all 6 breakpoints; commit `tests/__screenshots__/`
+      (reviewed).
+- [T008](https://github.com/brunogbv/cv/issues/142) [US1] Verify the **PDF is unchanged**: build and compare the generated PDF page-for-page
+      against a pre-003 build (quickstart Scenario 6) — rails flattened, entries/order intact,
+      QR + Download-PDF present.
+
+**Checkpoint**: CSS-only accessible rails work and are gated; the PDF is untouched. Shippable MVP.
+
+## Phase 4: User Story 2 — Accessible and works without JavaScript (Priority: P2)
+
+**Goal**: Rigorous a11y + the additive JS affordance layer — SR-exposed list, keyboard operable,
+no-JS reachability, reduced-motion, prev/next + position status.
+
+**Independent test**: quickstart Scenarios 2–5 — keyboard/SR navigation works; JS-off leaves all
+content reachable; reduced-motion suppresses non-essential motion.
+
+- [T009](https://github.com/brunogbv/cv/issues/143) [US2] Add `src/assets/rails.js` (progressive enhancement, screen-only effect): per-rail
+      prev/next controls, an `aria-live` position status, reduced-motion-aware scrolling (branch on
+      `matchMedia('(prefers-reduced-motion: reduce)')`), and **fail-visible** behavior (any error
+      leaves all content reachable). Reference it from `src/templates/index.html`; it is copied to
+      `dist/` by the existing `src/assets` copy (research D3, contract "Progressive enhancement").
+- [T010](https://github.com/brunogbv/cv/issues/144) [US2] Style the prev/next controls + position status in `src/assets/styles.css`
+      (screen-only; hidden in `@media print`); meet target-size (≥24px) and non-text contrast; absent
+      / harmless when JS does not run.
+- [T011](https://github.com/brunogbv/cv/issues/145) [US2] Verify accessibility + progressive enhancement (quickstart Scenarios 2–5): keyboard
+      reaches and moves through each rail with visible focus; a screen reader announces a labelled list
+      of N cards + position changes; **JS disabled → all cards reachable, nothing hidden**;
+      reduced-motion → no glide/animation. Update baselines if the resting state changed.
+
+**Checkpoint**: rails are fully accessible and degrade gracefully with no JS.
+
+## Phase 5: User Story 3 — Signature "route between nodes" & polish (Priority: P3)
+
+**Goal**: the distinctive, on-brand route-indicator signature + subtle rail polish; none of it in the
+PDF.
+
+**Independent test**: quickstart Scenario 8 — the route indicator tracks position, active node in the
+signal accent, reduced-motion respected, absent in the PDF, no layout shift.
+
+- [T012](https://github.com/brunogbv/cv/issues/146) [US3] Implement the **"route between nodes"** position indicator: CSS in
+      `src/assets/styles.css` (ordered nodes + connecting line; active node in the `signal` red) wired
+      to the rail position in `src/assets/rails.js` (and used as the `aria-live` target);
+      reduced-motion-aware pulse; screen-only (absent in `@media print`) (design.md, FR-008).
+- [T013](https://github.com/brunogbv/cv/issues/147) [US3] Add subtle focused-card emphasis + rail affordance polish in `src/assets/styles.css`
+      — reduced-motion-aware, **no layout shift** (FR-009, SC-008).
+- [T014](https://github.com/brunogbv/cv/issues/148) [US3] Update the committed baselines (`make visual-update`) for the signature/polish resting
+      state; confirm `make visual` green; verify the signature is **absent in the PDF** (quickstart
+      Scenario 8).
+
+**Checkpoint**: full interactive redesign complete, guarded by the gate.
+
+## Phase 6: Polish & cross-cutting
+
+- [T015](https://github.com/brunogbv/cv/issues/149) [P] Update `docs/architecture.md`: the card rails, `src/assets/rails.js`, and the
+      screen/print rail decoupling.
+- [T016](https://github.com/brunogbv/cv/issues/150) [P] Update `docs/ci-cd.md` if the Visual gate's rail-determinism setup changed.
+- [T017](https://github.com/brunogbv/cv/issues/151) [P] Update `AGENTS.md` if any convention changed (e.g. the `rails.js` progressive-enhancement
+      asset pattern).
+- [T018](https://github.com/brunogbv/cv/issues/152) [P] Add ADR `docs/adr/0004-interactive-card-rails.md` (CSS scroll-snap rails +
+      accessible-region pattern + the routing signature + no-JS-first decision); index it in
+      `docs/adr/README.md`.
+- [T019](https://github.com/brunogbv/cv/issues/153) Final verification: run quickstart Scenarios 1–8; `make lint` and `make visual` green;
+      confirm SC-001…SC-008.
+
+## Dependencies & execution order
+
+- **Foundational (T001)** → **US1 (T002–T008)** → **US2 (T009–T011)** → **US3 (T012–T014)** →
+  **Polish (T015–T019)**.
+- US2 and US3 depend on US1 (the rail structure must exist; each then updates baselines intentionally).
+- Within US1: T002 (template) → T003/T004/T006 (styles.css, sequential — same file) → T005 (print) →
+  T007 (baselines, needs T001) → T008 (PDF verify).
+- Polish T015–T018 are independent files (parallel); T019 is last (depends on everything).
+
+## Parallel opportunities
+
+- **US1**: T002 (`index.html`) can start alongside the first `styles.css` task, but T003/T004/T005/T006
+  all edit `src/assets/styles.css` and must be sequential.
+- **Polish**: T015, T016, T017, T018 touch four independent files → parallel.
+
+## Implementation strategy
+
+- **MVP = US1** — a complete, accessible, CSS-only rail with the PDF untouched; delivers the headline
+  interaction and is independently shippable.
+- Then US2 (the JS affordance layer + a11y/no-JS hardening), then US3 (the signature + polish). Each
+  US2/US3 change ships as code **plus a reviewed baseline update** — the gate makes every visual change
+  explicit.
+- Polish (docs + ADR + final verification) lands with or right after the stories it documents. No
+  constitution amendment is needed (v1.3.0 already recognizes the visual gate).


### PR DESCRIPTION
Persists the spec-kit planning artifacts for the **Interactive card rails** initiative (milestone [#5](https://github.com/brunogbv/cv/milestone/5), issues #135–#153) — banking the plan on `main` before implementation. **No code changes.**

## What this is
The next initiative after the 002 redesign: the three content-dense sections (Professional Experience, Additional Experience, Robotics Competitions) become **horizontally swipeable card rails** — one focal card + peek, snap-with-peek — layered on the existing vertical page. Direction B (rails-in-scroll-page), vanilla, per the brainstorm + clarify.

## Artifacts
- `spec.md` (+ Clarifications), `plan.md`, `research.md`, **`design.md`** (the `frontend-design` design pass), `data-model.md`, `contracts/rail-interaction-contract.md`, `quickstart.md`, `tasks.md` (19 tasks linked to issues), `checklists/requirements.md`.
- `.specify/feature.json` → `specs/003-interactive-card-rails`.

## Key decisions (grounded in a sourced a11y research pass)
- **Accessible-region + list**, not the APG carousel widget; `tabindex="0"` on the scroll container (Safari/older engines don't focus scrollers natively).
- **CSS scroll-snap** for swipe/peek/snap — **no-JS-first** (JS is additive: prev/next, `aria-live` position); nothing hidden without JS.
- **PDF unchanged** — rails are screen-only and flatten in `@media print`; no `pdf.js` change.
- **Signature**: a screen-only **"route between nodes"** position indicator (the rail *is* an ordered sequence → the marker is content-justified), reusing the existing red as the "live" accent — **no new color/font/dependency**.
- **No constitution amendment** — v1.3.0 already recognizes the visual gate; the gate is *extended* with deterministic rail baselines.

## Verification
`make lint` green (docs-only; MD013/MD040 clean); internal consistency checked (12 FRs / 8 SCs defined + referenced; quickstart maps every SC; tasks cover all stories). Self-review recorded.

Implementation follows via `/speckit-implement`, **US1 first** (the CSS-only accessible rails MVP, #136–#142).

🤖 Generated with [Claude Code](https://claude.com/claude-code)