### PR TITLE
Retire superseded PR preview deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,10 +114,18 @@ jobs:
             const shortSha = sha.slice(0, 7)
             const env = `preview-pr-${issue_number}`
 
-            // 1) Native surface: a Deployment tied to the head commit. required_contexts: [] so it
-            // never waits on other checks; transient + auto_inactive so superseded previews retire.
-            // Non-fatal: a deployment hiccup must not fail the deploy or block the comment below.
+            // 1) Native surface: a Deployment tied to the head commit → shows in the PR's
+            // "Deployments" box and on the commit. required_contexts: [] so it never waits on other
+            // checks. We explicitly mark the previous preview inactive so only the current commit's
+            // deployment stays active — `auto_inactive` does NOT apply to transient environments, so
+            // it can't do this for us. Non-fatal: a deployment hiccup must not fail the deploy or
+            // block the comment below.
             try {
+              const before = await github.rest.repos.listDeployments({
+                owner, repo, environment: env, per_page: 100
+              })
+              const prevId = before.data.length ? Math.max(...before.data.map((d) => d.id)) : null
+
               const dep = await github.rest.repos.createDeployment({
                 owner, repo, ref: sha, environment: env,
                 transient_environment: true, auto_merge: false, required_contexts: [],
@@ -127,8 +135,15 @@ jobs:
                 await github.rest.repos.createDeploymentStatus({
                   owner, repo, deployment_id: dep.data.id, state: 'success',
                   environment: env, environment_url: url, log_url: url,
-                  auto_inactive: true, description: `Vercel preview for ${shortSha}`
+                  description: `Vercel preview for ${shortSha}`
                 })
+                // Retire the prior preview for this PR so only the latest stays active.
+                if (prevId) {
+                  await github.rest.repos.createDeploymentStatus({
+                    owner, repo, deployment_id: prevId, state: 'inactive',
+                    description: `Superseded by ${shortSha}`
+                  })
+                }
               } else {
                 core.warning(`createDeployment returned no id: ${JSON.stringify(dep.data)}`)
               }


### PR DESCRIPTION
## Problem

Follow-up to #170/#171. The per-commit preview Deployment relied on `auto_inactive: true` to retire
prior previews, but GitHub's `auto_inactive` only affects **non-transient** deployments — and we set
`transient_environment: true`, so it was a no-op. A 2-commit test on #171 confirmed both deployments
stayed `success`. (Cosmetic: the Deployments box still showed the latest, but old previews lingered
"active" and the workflow comment was inaccurate.)

## Change (`.github/workflows/deploy.yml`)

Explicitly retire the prior preview: before creating the new deployment, look up the PR's environment
(`preview-pr-<n>`) and remember the previous deployment id; after posting the new `success` status,
post an `inactive` status to that previous deployment. Removed the no-op `auto_inactive` and corrected
the code comment. All non-fatal (try/catch) as before.

## Verification

- actionlint + full Super-Linter pass; independent review.
- **Self-tested on this PR's two commits**: the second push should mark the first commit's deployment
  `inactive` while the second stays `success` (evidence in the PR before merge).

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)