### PR TITLE
docs: correct scroll-snap guidance (native CSS Snap over JS scroll-jacking)

### DIFF
--- a/docs/interaction-gotchas.md
+++ b/docs/interaction-gotchas.md
@@ -10,36 +10,72 @@ enhancement scripts, the screen/print split), see [architecture.md](architecture
 
 ## Scroll-snap ↔ programmatic scroll
 
-- **CSS scroll-snap fights JS-driven smooth-scroll.** With `scroll-snap-type: … mandatory` on a
-  container *and* JavaScript that animates a scroll (section nav, prev/next, "scroll to card"), the
-  browser force-snaps mid-animation to the nearest snap point — the animation lands on the wrong
-  place, then jumps (the "hiccup").
-  **Rule:** pick **one** mechanism. Either CSS snap *or* JS-driven scrolling drives a given axis —
-  not both on the same container.
+> **Headline rule (learned the hard way in the 003 prototype): for a full-viewport "deck," use
+> _native_ CSS Scroll Snap and do NOT hand-roll a wheel/touch scroll-jacker.** A JS scroll-jacker
+> (intercept `wheel`/`touch`, animate `scrollTop` to the next index) inescapably **fights the
+> platform's own scroll momentum** — most visibly a macOS trackpad, where one two-finger swipe emits
+> ~40+ inertial `wheel` events with _no_ momentum-phase signal and events that aren't reliably
+> cancelable. The result is a sluggish, flickering start that no amount of tuning removes (we tried
+> rAF glides, momentum locks, pin-to-target — all treat the symptom). Native snap sidesteps it
+> entirely: the browser composits the scroll and applies snapping on its own thread. Hand-rolled
+> scroll-jacking is also [widely discouraged for usability](https://www.nngroup.com/articles/scrolljacking-101/).
 
-- **`mandatory` snap on sections taller than the viewport feels laggy.** `mandatory` always pulls to
-  the nearest snap point, so on tall (over-one-viewport) sections it fights the user's own scroll and
-  feels sticky/heavy.
-  **Rule:** reserve `mandatory` for a "deck" of **uniform, ~viewport-height** panels. For anything
-  that can exceed the viewport, use `proximity` (snaps only when you're already close) or no snap.
+**What actually works — a native deck (screen-only, so the PDF/print flow is untouched):**
 
-- **`scroll-snap-stop: always` does not give you one-section-per-gesture.** It only forces a stop at a
-  snap point *once you reach it*; it doesn't intercept the native incremental Arrow-key / wheel /
-  trackpad scroll that steps *between* snap points. So arrow keys still land mid-section.
-  **Rule:** if you truly need exactly one section per keypress/gesture (a true deck), that's a
-  **JS** concern (capture the key/wheel, animate to the next index) — and then it's JS-driven
-  scrolling, so per the first rule, don't also put `mandatory` snap on that container.
+```css
+@media not print {
+  html { scroll-snap-type: y mandatory; }
+  .deck-section {                 /* each panel is ~one viewport tall */
+    min-height: 100vh;
+    scroll-snap-align: start;
+    scroll-snap-stop: always;     /* a hard flick advances exactly ONE panel, never skips */
+    scroll-margin-top: 0;         /* land exactly on the panel top (see anchors, below) */
+  }
+}
+@media (prefers-reduced-motion: no-preference) { html { scroll-behavior: smooth; } }
+```
 
-Corollary: a clean scroll-snap "deck" wants uniform, roughly viewport-height panels and a single
-scroll driver. If the content can't be uniform or the sections must be taller than the viewport,
-prefer plain scrolling (optionally `proximity`) over forcing a deck.
+- **Native snap gives one-panel-per-flick for wheel / trackpad / touch by itself.** With
+  `mandatory` + `scroll-snap-stop: always` on uniform ~viewport-height panels, the browser rests on a
+  panel or animates to the neighbour and **cannot land between or skip** — the two states you want,
+  with zero JS. `scroll-snap-stop: always` is [Baseline / ~94%](https://caniuse.com/mdn-css_properties_scroll-snap-stop)
+  (Chrome/Edge, Safari 15+, Firefox 103+) — the older "Safari/Firefox don't support it" advice is stale.
+
+- **The one thing snap does _not_ cover is the keyboard** — Arrow / PageUp-Down do a small native
+  step, not a full panel. Add a **thin, orthogonal** JS layer only for that: on keydown, find the
+  current panel and call `neighbour.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth' })`. This
+  **coexists with `mandatory` snap** — CSS smooth-scroll and snap control orthogonal things and are
+  designed to work together; snapping runs _after_ a programmatic scroll settles. Keep this layer to
+  keyboard only; do **not** intercept `wheel`/`touch` (that's the scroll-jacker the headline rule
+  forbids). It's pure progressive enhancement — with no JS the native snap still works.
+
+- **Where the "CSS snap fights JS smooth-scroll hiccup" really comes from.** It is specifically CSS
+  `mandatory` snap fighting a JS scroll _you animate frame-by-frame or via `scrollTo({behavior})`_:
+  the browser force-snaps mid-animation and the glide lands wrong, then jumps. That is an argument to
+  **stop animating the scroll yourself**, not to abandon snap. Snap + native anchor/`scrollIntoView`
+  navigation do not fight (the browser reconciles them).
+
+- **`mandatory` snap on panels taller than the viewport feels laggy.** `mandatory` always pulls to the
+  nearest snap point, so on over-one-viewport panels it fights the user's own scroll and feels
+  sticky/heavy. **Rule:** reserve `mandatory` for a deck of **uniform, ~viewport-height** panels. For
+  anything that can exceed the viewport, use `proximity` (snaps only when already close) or no snap,
+  and let it scroll normally.
+
+**Libraries (evaluated during the 003 discovery — none warranted here).** For "centered, or animating
+to the neighbour," native CSS is the right tool — 0 bytes, no dependency, no-JS fallback, print-safe.
+Two turnkey options were rejected on this project's constraints: **fullPage.js** — its free tier is
+**GPLv3**, which would force this whole repo to be relicensed GPLv3 (or pay), _and_ it carries the
+same documented macOS-trackpad over-scroll bug; **Swiper** (MIT) — documented Mac-trackpad "jumps 2
+slides" bug (esp. Safari) and a weak no-JS story. A library is only worth it for things CSS can't do
+(cross-panel scroll-triggered animation orchestration, combined H+V decks, per-panel URL hashes,
+fine easing control) — none of which a section deck needs.
 
 ## In-page anchors
 
 - **`<base target="_blank">` silently breaks every in-page anchor.** A page-wide
   `<base target="_blank">` (added so external links open in a new tab) also applies to `href="#…"`
   links — nav links, card links, close/back buttons, "skip to content". Each one then opens a **new
-  tab and reloads the whole page** instead of jumping within the current page. It fails *silently* —
+  tab and reloads the whole page** instead of jumping within the current page. It fails _silently_ —
   nothing errors; the anchor just misbehaves.
   **Rule:** any in-page anchor (`href="#…"`) under a `<base target="_blank">` must set
   `target="_self"` explicitly. This bit the 002 section nav and again the 003 card links — treat it
@@ -51,7 +87,7 @@ prefer plain scrolling (optionally `proximity`) over forcing a deck.
 - Any **JS** scroll (`scrollTo`/`scrollIntoView` with `behavior: 'smooth'`) overrides the CSS
   `scroll-behavior` setting and ignores `prefers-reduced-motion`. Branch on
   `matchMedia('(prefers-reduced-motion: reduce)')` and pass `behavior: 'instant'` (or `'auto'`) when
-  reduce is set. Scroll-*snapping* itself is a resting position, not animation — keep it on; it's the
+  reduce is set. Scroll-_snapping_ itself is a resting position, not animation — keep it on; it's the
   animated glide you gate.
 
 ## A note on ADR 0004


### PR DESCRIPTION
## Context
`docs/interaction-gotchas.md` (added in #165) steered readers toward driving a full-viewport section
"deck" with JavaScript — intercept `wheel`/`touch`, animate `scrollTop` to the next index. The **003
prototype proved that inverts the right answer.** A hand-rolled scroll-jacker inescapably fights the
platform's own scroll momentum, most visibly a **macOS trackpad** (one two-finger swipe emits ~40+
inertial, not-reliably-cancelable `wheel` events with no momentum-phase signal), producing a
sluggish/flickering start that no amount of tuning removes. Switching to **native CSS Scroll Snap**
fixed it in *less* code, and the owner confirmed it "works perfectly."

Left as-is, the doc would actively mislead the next interaction-heavy change (incl. the pending 003
re-spec) into rebuilding the scroll-jacker.

## What changed
- Rewrote **"Scroll-snap ↔ programmatic scroll"** with a headline rule (use native snap; do **not**
  hand-roll wheel/touch scroll-jacking) and a working native-deck CSS snippet.
- Clarified that native snap gives one-panel-per-flick for wheel/trackpad/touch **by itself**
  (`mandatory` + `scroll-snap-stop: always` on uniform viewport-height panels); JS is needed **only**
  for the keyboard — a thin `scrollIntoView` layer that **coexists** with mandatory snap (they don't
  fight). The "hiccup" is specifically JS-*animated* scroll vs mandatory snap: an argument to stop
  animating the scroll yourself, not to abandon snap.
- Added the library findings from the discovery (**fullPage.js** GPLv3 + Mac trackpad bug; **Swiper**
  MIT but Mac "jumps 2 slides") and why none is warranted here.
- Converted single-asterisk italics → underscores in this file (markdownlint **MD049**; the prior lint
  run had skipped the rule on a `re2` module load error).

## Scope / safety
Documentation only; guidance is screen-only and the PDF/print flow is unaffected. Verified locally:
`make lint` green (Super-Linter, real exit 0); technical claims + internal/`architecture.md`
consistency reviewed (all citations from the 003 discovery's primary sources — caniuse, vendor
license pages, upstream issue trackers).

## References
- Supersedes the now-inverted guidance from #161 / #165.
- Emerged from the 003 interactive-CV prototype (branch `003-proto`, PR #156) trackpad-feel work.