### PR TITLE
US1 fix: deck.js to Standard style (unblock 003-deck lint)

### DIFF
--- a/src/assets/deck.js
+++ b/src/assets/deck.js
@@ -10,10 +10,10 @@
 // this only upgrades key presses to one-section-per-press. In print there is no keyboard scrolling,
 // and the deck layout itself is screen-only (styles.css @media not print), so this never affects the PDF.
 (function () {
-  var reduce = window.matchMedia('(prefers-reduced-motion: reduce)')
+  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)')
 
   function isField (t) {
-    var n = (t && t.tagName || '').toLowerCase()
+    const n = ((t && t.tagName) || '').toLowerCase()
     return n === 'input' || n === 'textarea' || n === 'select'
   }
 
@@ -23,11 +23,11 @@
 
   // The section we're resting on = the one whose top is nearest the top of the viewport.
   function currentIndex () {
-    var els = sections()
-    var best = 0
-    var bestDist = Infinity
-    for (var i = 0; i < els.length; i++) {
-      var d = Math.abs(els[i].getBoundingClientRect().top)
+    const els = sections()
+    let best = 0
+    let bestDist = Infinity
+    for (let i = 0; i < els.length; i++) {
+      const d = Math.abs(els[i].getBoundingClientRect().top)
       if (d < bestDist) { bestDist = d; best = i }
     }
     return best
@@ -35,10 +35,10 @@
 
   document.addEventListener('keydown', function (e) {
     if (isField(e.target) || e.repeat) return // ignore auto-repeat: one press = one section
-    var dir = (e.key === 'ArrowDown' || e.key === 'PageDown') ? 1 : (e.key === 'ArrowUp' || e.key === 'PageUp') ? -1 : 0
+    const dir = (e.key === 'ArrowDown' || e.key === 'PageDown') ? 1 : (e.key === 'ArrowUp' || e.key === 'PageUp') ? -1 : 0
     if (!dir) return
-    var els = sections()
-    var target = currentIndex() + dir
+    const els = sections()
+    const target = currentIndex() + dir
     if (target < 0 || target >= els.length) return
     e.preventDefault()
     els[target].scrollIntoView({ behavior: reduce.matches ? 'auto' : 'smooth', block: 'start' })


### PR DESCRIPTION
CI **Lint failed** on `deck.js` after US1 (#214) merged into `003-deck`: `standard` 17.1.0 flagged
`no-var` (I wrote it with `var`, copying the prototype's inline-script style) and a hard
`no-mixed-operators` error (`t && t.tagName || ''`). Rewrite in the repo's modern style
(`const`/`let`; `(t && t.tagName) || ''`) to match `reveal.js`. **Logic unchanged.**

Verified with `standard@17.1.0` directly (clean). Restores `003-deck` to a green lint state.

**Why local didn't catch it:** `make lint` was run in a `make worktree` sibling, where super-linter's
changed-file detection misfires (a worktree's `.git` is a file, not a dir) — it linted nothing and
reported "Successfully linted", a false green. Harness follow-up to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)