### PR TITLE
US4: accessibility / no-JS / reduced-motion hardening

### DIFF
--- a/src/assets/overlay.js
+++ b/src/assets/overlay.js
@@ -25,7 +25,7 @@
   const focusables = (overlay) => {
     return Array.prototype.slice
       .call(overlay.querySelectorAll(FOCUSABLE))
-      .filter((el) => el.offsetParent !== null)
+      .filter((el) => el.offsetParent !== null && el.tabIndex >= 0)
   }
 
   const deactivateBackground = () => {

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -736,3 +736,40 @@ h4 {
         font-size: 0.8rem;
     }
 }
+
+/* =====================================================================================
+   Accessibility hardening (US4): visible keyboard focus + reduced-motion. Screen-only.
+   Spec: FR-012, FR-014, US4. (Keyboard section nav, overlay focus trap/return, and the
+   no-JS :target baseline are handled in deck.js / overlay.js / the CSS above.)
+   ===================================================================================== */
+@media not print {
+    /* Clear, consistent focus ring on the interactive elements (WCAG 2.4.7). Rails use
+       scroll-padding-inline (above) so the ring isn't clipped by the scroll track. */
+    a.cv-summary:focus-visible,
+    .cv-detail-close:focus-visible,
+    .section-nav-list a:focus-visible {
+        outline: 2px solid var(--p-terra);
+        outline-offset: 3px;
+        border-radius: 0.35rem;
+    }
+}
+
+/* Reduced motion: keep everything functional, drop the non-essential animation. Snapping is a
+   resting position (kept); the smooth glide + reveal are already gated above. Here we also
+   neutralise the summary hover-lift and the overlay fade/scale so an overlay opens instantly. */
+@media (prefers-reduced-motion: reduce) {
+    .cv-summary,
+    .cv-detail,
+    .cv-detail-inner {
+        transition: none;
+    }
+
+    a.cv-summary:hover,
+    a.cv-summary:focus-visible {
+        transform: none;
+    }
+
+    .cv-detail-inner {
+        transform: none; /* card appears at full scale immediately (no scale-in) */
+    }
+}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -96,8 +96,8 @@
 
         <main>
         {{#if about_me}}
-        <section id="about" class="cv-section reveal">
-            <h2 class="cv-section-title" data-eyebrow="Who I am">About me</h2>
+        <section id="about" class="cv-section reveal" aria-labelledby="about-title">
+            <h2 id="about-title" class="cv-section-title" data-eyebrow="Who I am">About me</h2>
             <div class="card cv-card">
                 <div class="card-body">{{{markdown about_me}}}</div>
             </div>
@@ -108,8 +108,8 @@
         <!-- US3: screen shows proficiency CHIPS (.cv-skills, screen-only); PRINT keeps the original 002
              dot-bar grid (.print) verbatim, so the PDF's skills section is unchanged (SC-005). Both are
              rendered; .screen/.print toggle which one is visible per media. -->
-        <section id="skills" class="cv-section reveal">
-            <h2 class="cv-section-title" data-eyebrow="What I know">Skills</h2>
+        <section id="skills" class="cv-section reveal" aria-labelledby="skills-title">
+            <h2 id="skills-title" class="cv-section-title" data-eyebrow="What I know">Skills</h2>
             <ul class="cv-skills screen">
                 {{#each skills}}
                 <li style="--pct: {{ this.[1] }}%">{{ this.[0] }}</li>
@@ -131,10 +131,10 @@
         {{/if}}
 
         {{#if positions}}
-        <section id="experience" class="cv-section reveal">
-            <h2 class="cv-section-title" data-eyebrow="Where I've worked">Professional Experience</h2>
+        <section id="experience" class="cv-section reveal" aria-labelledby="experience-title">
+            <h2 id="experience-title" class="cv-section-title" data-eyebrow="Where I've worked">Professional Experience</h2>
             <!-- SCREEN: horizontal rail of short summary cards; each opens a full-screen :target detail. -->
-            <ul class="cv-rail screen">
+            <ul class="cv-rail screen" aria-label="Professional Experience — swipe or tab through entries">
                 {{#each positions}}
                 <li>
                     <a class="cv-summary" href="#e{{@index}}" target="_self">
@@ -148,7 +148,7 @@
             </ul>
             {{#each positions}}
             <div id="e{{@index}}" class="cv-detail screen" role="dialog" aria-modal="true" aria-labelledby="e{{@index}}-title">
-                <a class="cv-detail-backdrop" href="#experience" aria-label="Close details" target="_self"></a>
+                <a class="cv-detail-backdrop" href="#experience" target="_self" tabindex="-1" aria-hidden="true"></a>
                 <div class="cv-detail-inner">
                     <a class="cv-detail-close" href="#experience" target="_self" aria-label="Close details">&times;</a>
                     <div class="cv-detail-scroll">
@@ -189,9 +189,9 @@
         {{/if}}
 
         {{#if experience}}
-        <section id="additional" class="cv-section reveal">
-            <h2 class="cv-section-title" data-eyebrow="Courses &amp; training">Additional Experience</h2>
-            <ul class="cv-rail screen">
+        <section id="additional" class="cv-section reveal" aria-labelledby="additional-title">
+            <h2 id="additional-title" class="cv-section-title" data-eyebrow="Courses &amp; training">Additional Experience</h2>
+            <ul class="cv-rail screen" aria-label="Additional Experience — swipe or tab through entries">
                 {{#each experience}}
                 <li>
                     <a class="cv-summary" href="#x{{@index}}" target="_self">
@@ -205,7 +205,7 @@
             </ul>
             {{#each experience}}
             <div id="x{{@index}}" class="cv-detail screen" role="dialog" aria-modal="true" aria-labelledby="x{{@index}}-title">
-                <a class="cv-detail-backdrop" href="#additional" aria-label="Close details" target="_self"></a>
+                <a class="cv-detail-backdrop" href="#additional" target="_self" tabindex="-1" aria-hidden="true"></a>
                 <div class="cv-detail-inner">
                     <a class="cv-detail-close" href="#additional" target="_self" aria-label="Close details">&times;</a>
                     <div class="cv-detail-scroll">
@@ -246,9 +246,9 @@
         {{/if}}
 
         {{#if competitions}}
-        <section id="competitions" class="cv-section reveal">
-            <h2 class="cv-section-title" data-eyebrow="Earlier chapters">Robotics Competitions</h2>
-            <ul class="cv-rail screen">
+        <section id="competitions" class="cv-section reveal" aria-labelledby="competitions-title">
+            <h2 id="competitions-title" class="cv-section-title" data-eyebrow="Earlier chapters">Robotics Competitions</h2>
+            <ul class="cv-rail screen" aria-label="Robotics Competitions — swipe or tab through entries">
                 {{#each competitions}}
                 <li>
                     <a class="cv-summary" href="#c{{@index}}" target="_self">
@@ -262,7 +262,7 @@
             </ul>
             {{#each competitions}}
             <div id="c{{@index}}" class="cv-detail screen" role="dialog" aria-modal="true" aria-labelledby="c{{@index}}-title">
-                <a class="cv-detail-backdrop" href="#competitions" aria-label="Close details" target="_self"></a>
+                <a class="cv-detail-backdrop" href="#competitions" target="_self" tabindex="-1" aria-hidden="true"></a>
                 <div class="cv-detail-inner">
                     <a class="cv-detail-close" href="#competitions" target="_self" aria-label="Close details">&times;</a>
                     <div class="cv-detail-scroll">


### PR DESCRIPTION
## What
Fills the accessibility gaps across the deck / rails / overlays. Deck keyboard nav, overlay focus
trap+return, and the `:target` no-JS baseline were already in place (US1/US2) — this hardens the rest.

Closes #201, #202, #203, #204.

## Changes
- **Reduced motion (FR-014):** a `@media (prefers-reduced-motion: reduce)` block now also suppresses the
  US2 rail/overlay animation (summary hover-lift, overlay fade + card scale-in) — an overlay opens
  instantly and stays fully functional. Snapping is a resting position (kept); deck glide + reveal were
  already gated.
- **Visible focus (WCAG 2.4.7):** focus-visible outlines on summary cards, the overlay close, and nav
  links (rails use `scroll-padding-inline` so the ring isn't clipped).
- **Landmarks / labels:** each section is a labelled region (`aria-labelledby` → its `<h2>` id); each rail
  is a labelled list (`aria-label`).
- **Backdrops non-tabbable:** the overlay backdrops become `tabindex="-1" aria-hidden="true"` — a
  mouse/no-JS click-outside affordance; the visible close × (a real `#section` anchor) is the
  keyboard/AT/no-JS close control. `overlay.js`'s focus-trap now filters `tabIndex >= 0` so the backdrop
  isn't a phantom full-screen tab stop.

## Verification
- Pinned image: `make visual` **8/8**, **baselines unchanged** (aria/focus/reduced-motion don't alter the
  resting render or the PDF).
- Lint verified directly: `overlay.js` Standard-clean, `styles.css` stylelint-clean.
- Independent code-review: **no findings** (reduced-motion cascade keeps the card full-size when open;
  backdrop exclusion keeps mouse-close working; all `aria-labelledby` references resolve).

## Scope
Into `003-deck` (integration branch — no production deploy). Only **US5** (the Through-Line signature)
remains; then `003-deck` → `main` ships the full redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)