### PR TITLE
US5: the Through-Line signature (screen-only; PDF unchanged)

### DIFF
--- a/src/assets/deck.js
+++ b/src/assets/deck.js
@@ -43,4 +43,57 @@
     e.preventDefault()
     els[target].scrollIntoView({ behavior: reduce.matches ? 'auto' : 'smooth', block: 'start' })
   })
+
+  // Through-Line signature (US5): reflect the active section on the left-gutter progress spine.
+  // Screen-only progressive enhancement — with no JS the spine is a static index of jump links.
+  // deck.js loads in <head>, so defer DOM queries until the body exists (mirrors reveal.js).
+  const initThroughLine = () => {
+    const line = document.querySelector('.through-line')
+    if (!line) return
+    const nodes = [].slice.call(line.querySelectorAll('a[data-section]'))
+    if (!nodes.length) return
+    // Panels = the hero (header) followed by each node's section. The nearest-centred panel decides
+    // the active node; while the hero is centred no node is active yet (active = -1, empty fill).
+    const panels = [document.querySelector('header')].concat(nodes.map((n) => document.getElementById(n.dataset.section)))
+    const status = line.querySelector('.tl-status')
+    let ticking = false
+    const paint = () => {
+      ticking = false
+      const mid = window.innerHeight / 2
+      let nearest = 0
+      let best = Infinity
+      for (let i = 0; i < panels.length; i++) {
+        if (!panels[i]) continue
+        const r = panels[i].getBoundingClientRect()
+        const d = Math.abs((r.top + r.bottom) / 2 - mid)
+        if (d < best) { best = d; nearest = i }
+      }
+      const active = nearest - 1 // -1 on the hero; 0..n-1 once a section is centred
+      line.style.setProperty('--tl-progress', (active >= 0 && nodes.length > 1) ? active / (nodes.length - 1) : 0)
+      for (let i = 0; i < nodes.length; i++) {
+        nodes[i].classList.toggle('is-past', i < active)
+        nodes[i].classList.toggle('is-active', i === active)
+        if (i === active) nodes[i].setAttribute('aria-current', 'true')
+        else nodes[i].removeAttribute('aria-current')
+      }
+      if (status) {
+        status.textContent = (active >= 0) ? ('Section ' + (active + 1) + ' of ' + nodes.length + ': ' + (nodes[active].dataset.label || '')) : ''
+      }
+    }
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true
+        window.requestAnimationFrame(paint)
+      }
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll, { passive: true })
+    paint()
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initThroughLine)
+  } else {
+    initThroughLine()
+  }
 })()

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -773,3 +773,129 @@ h4 {
         transform: none; /* card appears at full scale immediately (no scale-in) */
     }
 }
+
+/* =====================================================================================
+   The signature — "The Through-Line" (US5): a fixed terracotta thread in the left gutter with
+   one node per section; the fill + active node advance as you snap. Screen-only (.screen → absent
+   in print). position:fixed reserves no layout box (CLS ≈ 0). deck.js sets --tl-progress + the
+   node states + an aria-live status; with no JS it's a static line of anchor-dot jump links.
+   Hidden below md — the top section-nav serves small screens. Spec: FR-013/014, US5, D8.
+   ===================================================================================== */
+@media not print {
+    .through-line {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 1025; /* below the section-nav (1030) */
+        display: flex;
+        align-items: center;
+        width: 2.25rem;
+        pointer-events: none; /* only the node links are interactive (re-enabled below) */
+    }
+
+    .through-line ol {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        height: min(60vh, 30rem);
+        margin: 0 auto;
+        padding: 0;
+        list-style: none;
+    }
+
+    /* faint full-height rail */
+    .through-line ol::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 50%;
+        width: 1px;
+        background-color: rgb(15 23 42 / 15%);
+        transform: translateX(-50%);
+    }
+
+    /* travelled portion: top → the active node, height driven by --tl-progress (0–1) */
+    .through-line ol::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 50%;
+        width: 1px;
+        height: calc(var(--tl-progress, 0) * 100%);
+        background-color: var(--p-terra);
+        transform: translateX(-50%);
+    }
+
+    .through-line li {
+        position: relative;
+        display: flex;
+    }
+
+    .through-line a {
+        position: relative;
+        z-index: 1;
+        display: block;
+        width: 11px;
+        height: 11px;
+        border-radius: 50%;
+        background-color: var(--p-cream);
+        border: 1px solid rgb(15 23 42 / 30%);
+        pointer-events: auto;
+    }
+
+    .through-line a.is-past,
+    .through-line a.is-active {
+        background-color: var(--p-terra);
+        border-color: var(--p-terra);
+    }
+
+    .through-line a.is-active {
+        transform: scale(1.5);
+    }
+
+    .through-line a:focus-visible {
+        outline: 2px solid var(--p-terra);
+        outline-offset: 3px;
+    }
+
+    /* the node's `.tl-node` span is the visual dot target; the label + live status are for AT only */
+    .through-line .tl-node {
+        display: block;
+        width: 100%;
+        height: 100%;
+    }
+
+    .through-line .tl-label,
+    .through-line .tl-status {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
+    /* Desktop signature; on small screens the top section-nav is the wayfinding. */
+    @media (width < 768px) {
+        .through-line {
+            display: none;
+        }
+    }
+}
+
+/* Reduced motion: the fill + node scale JUMP (state shown, no tween). */
+@media (prefers-reduced-motion: no-preference) {
+    .through-line ol::after {
+        transition: height 0.4s ease;
+    }
+
+    .through-line a {
+        transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+    }
+}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -56,6 +56,22 @@
         </div>
     </nav>
 
+    <!-- The signature: "The Through-Line" (US5). A fixed terracotta thread down the left margin whose
+         fill advances one node per section as you snap through the deck — an ambient progress spine +
+         a distributed-systems/dispatch nod (a route traversed hop by hop). Screen-only (.screen, hidden
+         in print) and position:fixed (reserves no layout box → CLS ≈ 0); hidden on small screens (the
+         top nav serves mobile). No JS: a static line of anchor-dot jump links. deck.js fills it. -->
+    <nav class="through-line screen" aria-label="Section progress">
+        <ol>
+            {{#if about_me}}<li><a href="#about" target="_self" data-section="about" data-label="About"><span class="tl-node"></span><span class="tl-label">About</span></a></li>{{/if}}
+            {{#if skills}}<li><a href="#skills" target="_self" data-section="skills" data-label="Skills"><span class="tl-node"></span><span class="tl-label">Skills</span></a></li>{{/if}}
+            {{#if positions}}<li><a href="#experience" target="_self" data-section="experience" data-label="Professional Experience"><span class="tl-node"></span><span class="tl-label">Experience</span></a></li>{{/if}}
+            {{#if experience}}<li><a href="#additional" target="_self" data-section="additional" data-label="Additional Experience"><span class="tl-node"></span><span class="tl-label">Additional</span></a></li>{{/if}}
+            {{#if competitions}}<li><a href="#competitions" target="_self" data-section="competitions" data-label="Robotics Competitions"><span class="tl-node"></span><span class="tl-label">Competitions</span></a></li>{{/if}}
+        </ol>
+        <span class="tl-status" aria-live="polite"></span>
+    </nav>
+
     <div class="container page">
         <header class="border-bottom border-2 border-dark mb-5 pb-5 pb-print-0 mb-print-1">
             <div class="row">


### PR DESCRIPTION
## What
The 003 **signature**: a fixed terracotta thread down the left gutter with one node per section; the
fill + active node advance as you snap through the deck — an ambient progress spine and a
distributed-systems/dispatch nod (a route traversed hop by hop). It doubles as a bonus jump-nav.

Closes #205, #206, #207, #208. **This is the last of the five user stories.**

## How it works
- `index.html`: a `.through-line .screen` nav (`<ol>` of section anchor-dots + a visually-hidden
  `aria-live` status), placed after the top nav.
- `styles.css` (`@media not print`): fixed left-gutter rail (`position:fixed` → CLS 0), a faint full
  rail + a terracotta fill (`height: calc(var(--tl-progress) * 100%)`), node dots with
  `.is-past`/`.is-active`, visually-hidden labels/status, **hidden below md** (the top nav serves
  mobile); transitions only under `prefers-reduced-motion: no-preference`.
- `deck.js`: `initThroughLine` (DOMContentLoaded-guarded — `deck.js` is in `<head>`) sets
  `--tl-progress`, the active node + `aria-current`, and the `aria-live` "Section N of M" on scroll
  (rAF-throttled). On the **hero, no node is active yet**.

**No-JS:** a static line of anchor-dot jump links. **Reduced-motion:** state jumps, no tween.

## Verification
- Pinned image: `make visual` **8/8**, **pdf-visual ✓, PDF baseline unchanged** (screen-only).
- Lint direct: `deck.js` Standard-clean, `styles.css` stylelint-clean.
- Behaviour probed: hero → no active node (progress 0); Additional → node 4/5 active, progress 0.75,
  aria-live "Section 4 of 5". Viewport screenshots confirm the spine + fill.
- Code-review: two findings **fixed** (empty-nodes guard; hero no longer falsely marks node 1 active).

## ⚠️ Gate coverage note (harness follow-up)
The fixed Through-Line is **not captured by the `fullPage` visual baselines** (a known Playwright
`fullPage` + `position:fixed` limitation) — so the signature itself isn't visual-regression-protected
yet. The feature is verified working (viewport shots + geometry/aria probe). I'll raise a `harness`
issue to add a **viewport-level snapshot** covering the fixed chrome.

## Next
With US5 merged, **all five stories are on `003-deck`** → then `003-deck` → `main` ships the whole
interactive editorial deck to valerio.dev in one production deploy and closes milestone #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)