### PR TITLE
Harness principle: guardrails over guidance (canonical in docs/, mirrored in constitution)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -49,18 +49,15 @@ gate over a documented practice (Principle VII) — see
 ### VII. Guardrails over guidance — prefer executable gates (NON-NEGOTIABLE)
 
 Documentation states intent; a **gate enforces it**. For a mistake that is **costly or likely to
-recur** — breaking the PDF, shipping a stale visual baseline, leaking a secret, regressing
-accessibility — the durable fix is a **deterministic check** (a test, validation, lint rule, hook, or
-CI gate that mechanically passes or fails), not a line in a doc asking a fallible human or agent to
-remember. Everyone is prone to mistakes; documented best practice relies on memory and diligence at
-exactly the moment they lapse. So when a task surfaces such a mistake (Principle VI), reach for a gate
-first: make the wrong thing fail loudly and automatically. **What is non-negotiable is that
-documentation alone is never the final answer to a real, recurring mistake** — when a gate is
-genuinely impractical today, the documented practice is a stopgap that ships *with* a filed `harness`
-issue to add the gate. A near-miss on something that matters, caught only by inspection, is itself the
-signal that a gate is missing — file it and treat closing that gap as the real fix, not the catch.
-(Self-review under Principle II still backstops everything; this principle is about converting the
-mistakes that recur or bite hard into gates.)
+recur**, the durable fix is a **deterministic check** (a test, validation, lint rule, hook, or CI gate
+that mechanically passes or fails), not a doc asking a fallible human or agent to remember. Reach for a
+gate first; **what is non-negotiable is that documentation alone is never the final answer** to a real,
+recurring mistake — when a gate is impractical today, a documented practice is a stopgap that ships
+*with* a filed `harness` issue to add the gate, and a near-miss caught only by inspection is the signal
+that a gate is missing. This principle applies **repo-wide, not only under spec-kit** — its canonical
+statement (with rationale and the gates we already run) lives in
+[`docs/engineering-principles.md`](../../docs/engineering-principles.md). (Self-review under Principle
+II still backstops everything.)
 
 ## Development Workflow
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -42,8 +42,25 @@ config.
 ### VI. The harness is a living system
 
 When a task reveals a systemic gap in the harness (conventions, docs, `.claude/` hooks, the Dev
-Container, CI, spec-kit), codify the fix rather than patching the symptom — see
+Container, CI, spec-kit), codify the fix rather than patching the symptom — preferring an executable
+gate over a documented practice (Principle VII) — see
 [`docs/contributing.md`](../../docs/contributing.md) ("Improving the harness").
+
+### VII. Guardrails over guidance — prefer executable gates (NON-NEGOTIABLE)
+
+Documentation states intent; a **gate enforces it**. For a mistake that is **costly or likely to
+recur** — breaking the PDF, shipping a stale visual baseline, leaking a secret, regressing
+accessibility — the durable fix is a **deterministic check** (a test, validation, lint rule, hook, or
+CI gate that mechanically passes or fails), not a line in a doc asking a fallible human or agent to
+remember. Everyone is prone to mistakes; documented best practice relies on memory and diligence at
+exactly the moment they lapse. So when a task surfaces such a mistake (Principle VI), reach for a gate
+first: make the wrong thing fail loudly and automatically. **What is non-negotiable is that
+documentation alone is never the final answer to a real, recurring mistake** — when a gate is
+genuinely impractical today, the documented practice is a stopgap that ships *with* a filed `harness`
+issue to add the gate. A near-miss on something that matters, caught only by inspection, is itself the
+signal that a gate is missing — file it and treat closing that gap as the real fix, not the catch.
+(Self-review under Principle II still backstops everything; this principle is about converting the
+mistakes that recur or bite hard into gates.)
 
 ## Development Workflow
 
@@ -62,4 +79,4 @@ that links its issue with `Closes #<n>`.
 This constitution reflects and defers to [`AGENTS.md`](../../AGENTS.md); amendments update both and
 keep them consistent. All PRs are expected to comply, and added complexity must be justified.
 
-**Version**: 1.3.0 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-03
+**Version**: 1.4.0 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-05

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,8 +132,9 @@ don't just patch it ad-hoc:
   or CI check that mechanically passes or fails) does not. For a **costly or recurring** mistake, the
   fix to reach for is a gate that makes the wrong thing fail loudly and automatically. Documentation
   alone is never the final answer: it's a stopgap only when a gate is genuinely impractical, and then
-  it ships *with* a filed issue to add the gate. This is **Principle VII** of the
-  [constitution](.specify/memory/constitution.md).
+  it ships *with* a filed issue to add the gate. Canonical statement (applies repo-wide, not just under
+  spec-kit): [`docs/engineering-principles.md`](docs/engineering-principles.md) ("Guardrails over
+  guidance"), mirrored as constitution Principle VII.
 - **A near-miss caught only by inspection means a gate is missing.** If you (or a review) catch a real
   problem by eye that no gate would have caught, the catch is not the fix — closing the gap with a gate
   is. File it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,16 @@ don't just patch it ad-hoc:
 
 - **Name the gap and ask** whether to codify the fix into the harness — prefer fixing the system over
   the symptom. Whether to codify now, defer, or skip is the owner's call.
+- **Prefer a gate over a doc.** A documented best practice relies on a fallible human or agent
+  remembering it at the right moment; a **deterministic gate** (a test, validation, lint rule, hook,
+  or CI check that mechanically passes or fails) does not. For a **costly or recurring** mistake, the
+  fix to reach for is a gate that makes the wrong thing fail loudly and automatically. Documentation
+  alone is never the final answer: it's a stopgap only when a gate is genuinely impractical, and then
+  it ships *with* a filed issue to add the gate. This is **Principle VII** of the
+  [constitution](.specify/memory/constitution.md).
+- **A near-miss caught only by inspection means a gate is missing.** If you (or a review) catch a real
+  problem by eye that no gate would have caught, the catch is not the fix — closing the gap with a gate
+  is. File it.
 - **If the owner agrees**, raise a `harness`-labeled issue (see
   [`docs/contributing.md`](docs/contributing.md)) and handle it as its own change, separate from the
   task that surfaced it. `harness` is a grouping **label, not a milestone** — this work is ongoing.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Developer documentation lives in [`docs/`](docs/):
 - [Local development](docs/local-development.md) — set up the Dev Container, everyday commands, and the change workflow (start here).
 - [Architecture](docs/architecture.md) — code structure, the build pipeline, the content data model, and how the site is served.
 - [CI/CD](docs/ci-cd.md) — the GitHub Actions workflows (Lint, Dev Container prebuild, Vercel Deploy) and the Vercel deploy model.
+- [Engineering principles](docs/engineering-principles.md) — durable, tooling-agnostic principles (e.g. prefer executable gates over documented practice).
 - [`AGENTS.md`](AGENTS.md) — conventions for working in this repo (build via the Makefile, Dev Container, spec-driven development).
 
 ## Getting started

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@ agent-oriented quick reference, see [`AGENTS.md`](../AGENTS.md).
 - **[CI/CD](ci-cd.md)** — the GitHub Actions workflows (Lint, Dev Container prebuild, Vercel Deploy) and the Vercel deploy model.
 - **[Contributing & Issue Tracking](contributing.md)** — how work is tracked in GitHub (issues,
   milestones, labels; projects optional) and how to raise a well-formed issue.
+- **[Engineering principles](engineering-principles.md)** — durable, tooling-agnostic principles for
+  keeping the repo healthy, starting with "guardrails over guidance" (prefer executable gates over
+  documented practice).
 - **[Architecture Decision Records](adr/)** — significant technical decisions and their rationale.
 - **[Spec-driven development](spec-driven.md)** — the spec-kit `/speckit-*` workflow for non-trivial features.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -158,8 +158,9 @@ missing convention, or an undocumented assumption):
 2. **Propose codifying, gate first** — ask whether to fix the system rather than patch the symptom
    once. For a **costly or recurring** mistake, **prefer a deterministic gate** (a test, validation,
    lint rule, hook, or CI check that mechanically passes or fails) over a documented best practice: a
-   doc relies on a fallible human or agent remembering it, a gate does not (constitution Principle VII,
-   "Guardrails over guidance"). Documentation alone is never the final answer — it's a stopgap only
+   doc relies on a fallible human or agent remembering it, a gate does not (see
+   [`engineering-principles.md`](engineering-principles.md), "Guardrails over guidance"; mirrored as
+   constitution Principle VII). Documentation alone is never the final answer — it's a stopgap only
    when a gate is genuinely impractical, and then it ships with a filed issue to add the gate. A
    near-miss on something that matters, caught only by inspection, is itself the signal that a gate is
    missing. The owner decides: codify now, defer, or skip.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -155,8 +155,14 @@ deliberately, not ad-hoc. When a task reveals a **systemic gap** in it (a recurr
 missing convention, or an undocumented assumption):
 
 1. **Name it** — state the gap the specific issue revealed.
-2. **Propose codifying** — ask whether to fix the system (a convention / doc / tooling change)
-   rather than patch the symptom once. The owner decides: codify now, defer, or skip.
+2. **Propose codifying, gate first** — ask whether to fix the system rather than patch the symptom
+   once. For a **costly or recurring** mistake, **prefer a deterministic gate** (a test, validation,
+   lint rule, hook, or CI check that mechanically passes or fails) over a documented best practice: a
+   doc relies on a fallible human or agent remembering it, a gate does not (constitution Principle VII,
+   "Guardrails over guidance"). Documentation alone is never the final answer — it's a stopgap only
+   when a gate is genuinely impractical, and then it ships with a filed issue to add the gate. A
+   near-miss on something that matters, caught only by inspection, is itself the signal that a gate is
+   missing. The owner decides: codify now, defer, or skip.
 3. **Track it** — if the owner agrees, raise an issue with the **`harness`** label (create it once
    if missing) plus a type label (`documentation` for convention/doc changes, `maintenance` for
    tooling/CI/Dev Container), and a body covering the recurring problem and the proposed

--- a/docs/engineering-principles.md
+++ b/docs/engineering-principles.md
@@ -1,0 +1,54 @@
+# Engineering principles
+
+Durable principles for how this repo is built and kept healthy. Unlike the
+[constitution](../.specify/memory/constitution.md) — which formalizes the spec-kit / spec-driven
+workflow and is in play mainly when running the `/speckit-*` skills — these apply **repo-wide, always,
+regardless of tooling**. This document is the canonical home; the constitution and
+[`AGENTS.md`](../AGENTS.md) mirror the essentials and point here.
+
+## Guardrails over guidance — prefer executable gates
+
+**Documentation states intent; a gate enforces it.** A documented best practice relies on a fallible
+human or agent remembering it at exactly the moment their attention lapses — which is exactly when
+mistakes happen. A **deterministic gate** does not: a test, validation, lint rule, hook, or CI check
+that mechanically passes or fails cannot be forgotten.
+
+So for a mistake that is **costly or likely to recur** — breaking the PDF, shipping a stale visual
+baseline, leaking a secret, regressing accessibility — the durable fix is a gate, not a note. Reach for
+one first: **make the wrong thing fail loudly and automatically.**
+
+**Documentation alone is never the final answer to a real, recurring mistake.** When a gate is genuinely
+impractical *today*, a documented practice is a stopgap — and it ships *with* a filed
+[`harness`](contributing.md#improving-the-harness) issue to add the gate. A best-practice doc with no
+gate behind it is a debt, not a solution.
+
+**A near-miss caught only by inspection is the signal that a gate is missing.** If you (or a review)
+catch a real, costly problem by eye that no gate would have caught, the catch is not the fix — closing
+that gap with a gate is. File it, and treat *that* as the work.
+
+### Why this matters here
+
+This is a tiny static-site repo with **no unit/integration suite** — quality leans on a few automated
+gates plus self-review. That makes it *more* important, not less, to convert every recurring or
+high-cost failure mode into a gate, so the safety net grows over time instead of relying on vigilance.
+
+### In practice
+
+- The gates we already have: **Super-Linter** (`make lint`), the **visual-regression + PDF-render**
+  check (`make visual`), and the **self-review Stop hook** (`.claude/hooks/review-gate.sh`). See
+  [CI/CD](ci-cd.md).
+- Self-review (constitution Principle II) still backstops everything — this principle is about
+  converting the mistakes that recur or bite hard into gates, not about replacing judgment.
+- When you find a gap, follow ["Improving the harness"](contributing.md#improving-the-harness):
+  propose the gate, and if it can't land now, file a `harness` issue so it's tracked.
+
+> Scope check: this is not "gate every one-off typo." It's "never answer a *costly or recurring*
+> mistake with documentation alone." Trivial, unlikely-to-recur mistakes don't need a gate.
+
+## Related
+
+- [Constitution, Principle VII](../.specify/memory/constitution.md) — the spec-kit-era mirror of this
+  principle.
+- [`AGENTS.md` → "Improving the harness"](../AGENTS.md) — how to apply it when a task surfaces a gap.
+- [Contributing → "Improving the harness"](contributing.md#improving-the-harness) — the issue-raising
+  process for codifying fixes.


### PR DESCRIPTION
Adds a governing principle: for costly or recurring mistakes, **prefer a deterministic gate over a
documented practice**. Prompted by the #225 near-miss (a stale visual baseline that no "be careful"
note would have caught — only a tightened gate). Closes #227.

## Where it lives
The constitution is spec-kit-scoped (mainly in play under `/speckit-*`), so a repo-wide principle
shouldn't live there alone. The **canonical home is a new tooling-agnostic doc**; the constitution and
AGENTS.md mirror the essentials and point to it.

- **NEW `docs/engineering-principles.md`** — the canonical "Guardrails over guidance" statement:
  documentation states intent, a gate enforces it; **documentation alone is never the final answer** to
  a real, recurring mistake (a stopgap doc ships *with* a filed `harness` issue); a **near-miss caught
  only by inspection signals a missing gate**; scope check ("not every one-off typo"); the gates we
  already run; and that self-review (Principle II) still backstops.
- **`.specify/memory/constitution.md`** — Principle VII kept as a concise mirror that points to the doc
  and notes it applies repo-wide; version **1.3.0 → 1.4.0**.
- **`AGENTS.md`** + **`docs/contributing.md`** ("Improving the harness") — "gate first", pointing at the
  doc as canonical (mirrored as constitution Principle VII).
- **`README.md`** + **`docs/README.md`** — index the new doc.

## Self-review
Two independent review passes across all 5 docs came back clean: canonical vs mirror is unambiguous and
consistent, every relative link/anchor resolves, the three gates are named correctly, and there's no
contradiction with Principle II (self-review) or IV (CI gates / no unit suite). Scoped the constitution's
`(NON-NEGOTIABLE)` tag to "documentation alone is never the final answer" so it doesn't conflict with its
own fallback. Docs-only; markdownlint clean.

This PR is the *documentation* of the principle; the actual gates it obligates us toward (starting with
#225, plus #221/#223/#216) are separate follow-up work — which is exactly the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)