### PR TITLE
Document the 003 editorial deck: architecture.md + ADR 0004

### DIFF
--- a/docs/adr/0003-visual-regression-and-screen-print-decoupling.md
+++ b/docs/adr/0003-visual-regression-and-screen-print-decoupling.md
@@ -88,3 +88,9 @@ pinned via `SOURCE_DATE_EPOCH` so the PDF is stable day-to-day. A change to the 
 now fails a PR, and intentional PDF changes update baselines via `make visual-update` (as the screen
 snapshots do). This strengthens decision **1** without changing it (the original `pdf.spec.js`
 validity check stays).
+
+**Update (003):** decision **2** said "a CSS media split … leaves `pdf.js` untouched (no
+`emulateMedia`)." The 003 interactive deck reversed that — `pdf.js` now calls
+`page.emulateMedia({ media: 'print' })` before navigating, so the screen's own webfonts and 100vh deck
+can't leak into the PDF. See [ADR 0004](0004-native-scroll-snap-editorial-deck.md) (decision 5). The
+gate and the screen/print decoupling (decisions 1 and 3) stand.

--- a/docs/adr/0004-native-scroll-snap-editorial-deck.md
+++ b/docs/adr/0004-native-scroll-snap-editorial-deck.md
@@ -1,0 +1,91 @@
+# 0004 — Interactive CV as a native-scroll-snap editorial deck
+
+- **Status:** Accepted — implemented across the `003-interactive-card-rails` milestone (US1 deck,
+  US2 rails + detail overlays, US3 editorial restyle, US4 accessibility, US5 Through-Line; integration
+  #222) and refined by the Skills rework (#226)
+- **Date:** 2026-07-05
+
+## Context
+
+The 002 redesign ([ADR 0003](0003-visual-regression-and-screen-print-decoupling.md)) gave the screen a
+card/section layout with a sticky nav and a subtle scroll-reveal, and — crucially — a
+**visual-regression + PDF gate** plus a **screen/print CSS decoupling** that lets the on-screen page be
+rich while the PDF stays a clean, linear document. That decoupling was explicitly built as "the
+platform for future screen-only interactivity."
+
+003 spends that platform: make the digital CV distinctly more engaging and memorable — a bold,
+interactive experience — **without** touching the PDF, the content model (`metadata.js`), or the
+static, no-backend build.
+
+Forces:
+
+- The experience must be **memorable but disciplined** — one signature moment, not novelty everywhere.
+- Content-dense sections (Experience, Additional, Competitions, and later Skills) are long lists;
+  scrolling a wall of them is dull. They should be **flick-through** on touch and fully navigable by
+  keyboard and pointer.
+- **Progressive enhancement is non-negotiable:** no content may hide behind a gesture; everything must
+  work with no JavaScript, respect `prefers-reduced-motion`, and be keyboard- and screen-reader-usable.
+- The page itself must **never scroll horizontally** — rails scroll within their own track.
+- The **PDF stays byte-identical** and the visual + PDF gate keeps guarding it.
+- Stay **vanilla** — HTML/CSS + light progressive-enhancement JS; no framework; Handlebars retained.
+
+## Decision
+
+Build the screen as a **full-viewport scroll-snap "deck"** of editorial panels, with content-dense
+sections as **card rails** that open **detail overlays**, one **signature** motion, and everything
+**screen-only** so the PDF is untouched.
+
+1. **Native CSS Scroll Snap deck.** `scroll-snap-type: y mandatory` on `<html>`, each section/hero at
+   `min-height: 100vh` with `scroll-snap-align: start; scroll-snap-stop: always`. The browser owns
+   wheel/trackpad/touch momentum — **no scroll-jacking JS** (a hand-rolled scroller fights native
+   momentum; see [interaction-gotchas.md](../interaction-gotchas.md)). `deck.js` only upgrades
+   **keyboard** nav to one-section-per-press and drives the Through-Line; tall panels relax to
+   top-alignment (`justify-content: safe center`) so nothing is clipped.
+2. **Summary-card rails + `:target` detail overlays.** Each dense section is a horizontal `.cv-rail` of
+   short `.cv-summary` cards (`overflow-x: auto; scroll-snap-type: x mandatory; overscroll-behavior:
+   contain`, so a rail fling never disturbs the vertical deck). A card is an `<a href="#id">`; the
+   overlay is `<div id="id" class="cv-detail">` shown via `:target` — **open / close / scroll-lock /
+   backdrop are pure CSS and work with no JS.** `overlay.js` layers dialog semantics on top (focus
+   trap/return, Escape, `aria-modal`). A pure-CSS **swipe affordance** (right-edge fade + chevron) hints
+   the rails scroll.
+3. **The "Through-Line" signature.** A single fixed left-gutter progress thread that fills as you snap
+   through the deck — the one memorable moment, disciplined and screen-only (hidden below 768px).
+4. **Editorial restyle, screen-only.** Vendored **Fraunces** + **Spline Sans** (no CDN, applied
+   `media="screen"`), a warm palette, and eyebrow labels; Skills became category-card rails (#226)
+   instead of a proficiency-chip wall.
+5. **PDF isolation via `emulateMedia`.** `src/utils/pdf.js` now calls
+   `page.emulateMedia({ media: 'print' })` **before** navigating, so screen-only rules and the
+   `media="screen"` webfonts are never applied or even fetched for the PDF. **This reverses ADR 0003's
+   "`pdf.js` is unchanged (no `emulateMedia`)" decision:** with a screen this rich, relying on
+   Chromium's default print emulation was too easy to break silently; making `pdf.js` assert print
+   media is a small, deterministic guarantee that the PDF renders exactly the print document.
+
+## Alternatives considered
+
+- **A JS scroll-jacking library (fullPage.js-style).** Rejected: fights native trackpad/touch momentum
+  (the exact thrash hit while prototyping), adds weight, and breaks the no-JS baseline. Native
+  scroll-snap gives the "rest on a section" feel for free.
+- **Keep the 002 vertical page, just bolt on the rails.** Rejected: the deck is what makes it feel like
+  an *experience*; the brief was memorable, not incremental.
+- **JS-driven overlays (a modal library, or `<dialog>` only).** Rejected: the `:target` baseline works
+  with no JS and is what the PDF path relies on; `<dialog>`/JS are the enhancement, not the foundation.
+- **A separate print template, or leaving `pdf.js` on default media.** Rejected: one template keeps
+  content parity by construction; default-media print proved fragile once the screen carried its own
+  fonts and a 100vh deck — hence the `emulateMedia` guarantee.
+- **Proficiency bars / a chip wall for Skills.** Rejected during #226: self-rated percentages read
+  junior and the chip wall overflowed on mobile; category-card rails reuse the same components and read
+  better.
+
+## Consequences
+
+- **Positive:** a distinctive, accessible screen experience that reuses one rail/overlay vocabulary
+  across every dense section; the PDF is provably the print document (`emulateMedia` + the pixel gate);
+  the no-JS, reduced-motion, and keyboard paths all work by construction.
+- **Negative / trade-offs:** more screen-only CSS/JS to maintain; the deck's `100vh` panels make the
+  **fullPage** visual snapshots tall, so a single-section change can fall under the gate's
+  `maxDiffPixelRatio` at wide widths (found via a Skills near-miss — tracked as #225); the swipe
+  affordance persists at a rail's scroll-end (an accepted pure-CSS trade-off). Decision 5 amends ADR
+  0003's decision 2.
+- **Follow-ups:** tighten or replace the fullPage visual budget so section-scoped changes always
+  register (#225); the gate weaknesses around fixed chrome (#221) and the `make visual` dev-watch race
+  (#223) remain open.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ supersedes it and flip the old one's **Status** to `Superseded by ADR-XXXX`.
 - [0001 — Modernize the build runtime: Node 22 + Playwright](0001-modernize-build-runtime.md)
 - [0002 — Build in CI and deploy prebuilt to Vercel](0002-vercel-prebuilt-deploy.md)
 - [0003 — Visual-regression gate + screen/print decoupling for the CV redesign](0003-visual-regression-and-screen-print-decoupling.md)
+- [0004 — Interactive CV as a native-scroll-snap editorial deck](0004-native-scroll-snap-editorial-deck.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,8 @@ backend, database, or client-side framework — the page is plain HTML/CSS produ
 │   │   └── metadata.js           # CV content — the data model (see below)
 │   ├── templates/
 │   │   └── index.html            # Handlebars page template (Bootstrap 5 markup)
-│   ├── assets/                   # Copied verbatim into dist/: styles.css, reveal.js, photo.jpg,
-│   │                             #   favicons, url-qr-code.svg
+│   ├── assets/                   # Copied verbatim into dist/: styles.css, reveal.js, deck.js,
+│   │                             #   overlay.js, photo.jpg, favicons, url-qr-code.svg
 │   └── utils/
 │       ├── pdf.js                # Playwright HTML → PDF renderer
 │       └── helpers/
@@ -23,6 +23,7 @@ backend, database, or client-side framework — the page is plain HTML/CSS produ
 ├── tests/                        # Playwright visual-regression + PDF gate (see ci-cd.md)
 │   ├── visual.spec.js            #   fullPage snapshots at the 6 breakpoints
 │   ├── pdf.spec.js               #   asserts a valid PDF was built
+│   ├── pdf-visual.spec.js        #   per-page pixel diff of the PDF against baselines
 │   ├── snapshot.css              #   test-only styles for deterministic capture
 │   └── __screenshots__/          #   committed baseline PNGs
 ├── playwright.config.js          # Test runner config (breakpoints, snapshot tolerance)
@@ -48,7 +49,8 @@ The whole build is `src/build.js`, run via `node src/build.js` (wrapped by `npm 
 
 1. **Empties `dist/`** — `fs.emptyDirSync(outputDir)` (`outputDir` = `<repo>/dist`).
 2. **Copies assets** — `src/assets/` → `dist/` verbatim (styles, `reveal.js`, photo, favicons, QR
-   code), and vendors Bootstrap / Font Awesome / Roboto (CSS + fonts) from pinned `node_modules` into
+   code), and vendors Bootstrap / Font Awesome / Roboto plus the screen-only editorial webfonts
+   **Fraunces** (display) and **Spline Sans** (body) (CSS + fonts) from pinned `node_modules` into
    `dist/vendor/`, so the page and PDF need no CDN at build or render time (#24).
 3. **Registers the `markdown` helper** so templates can render Markdown content fields to HTML.
 4. **Compiles the template** — reads `src/templates/index.html`, compiles it with Handlebars, and
@@ -74,10 +76,10 @@ construction, while their **presentation is decoupled via CSS media** (one templ
 no separate print template). To keep that decoupling watertight, `pdf.js` calls
 `page.emulateMedia({ media: 'print' })` **before** navigating, so screen-only rules (`@media not print`)
 and screen-only assets (e.g. `media="screen"` webfonts) are never applied or even fetched for the PDF —
-it renders exactly the print document. On screen the CV is a rich,
-card/section-based layout with a sticky section nav and a subtle scroll-reveal; `@media print` flattens
-the cards back to a clean linear document, hides the nav, and disables the animation, so the PDF is
-unchanged by the redesign. The `screen` / `print` classes also swap the cross-links — the on-screen
+it renders exactly the print document. On screen the CV is a **full-viewport scroll-snap deck**
+(feature 003) — card rails, detail overlays, and a Through-Line signature (see *Template & styling*);
+`@media print` flattens all of it to a clean linear document — stacked entries, no deck / rails /
+overlays / nav — so the PDF is unchanged by the redesign. The `screen` / `print` classes also swap the cross-links — the on-screen
 page shows a "Download PDF" link, the print/PDF version a QR code back to the site
 (`src/templates/index.html`, `src/assets/styles.css`).
 
@@ -92,7 +94,7 @@ All CV content lives in `src/metadata/metadata.js`, which exports a single objec
 | `title`        | string   | Role/headline; also part of the PDF filename slug.                 |
 | `facts`        | array    | Contact/location items, each `{ icon, value }` (raw HTML strings). |
 | `about_me`     | string   | Markdown — rendered via the `{{markdown}}` helper.                 |
-| `skills`       | array    | Tuples `[label, percent]`; `percent` drives the skill-bar width.   |
+| `skills`       | array    | Categories `[{ category, kind, items }]`; `items` are skill-name strings (no grading). Screen: category-card rails; print: labelled lists. |
 | `positions`    | array    | Professional experience (see entry shape below).                   |
 | `experience`   | array    | Additional experience (same entry shape).                          |
 | `competitions` | array    | Robotics competitions (same shape, without `skills`).              |
@@ -110,30 +112,43 @@ Font Awesome `<i>` tags and `<a>` links.
 ## Template & styling
 
 - `src/templates/index.html` is a Handlebars template producing a Bootstrap 5 single-page layout.
-  Bootstrap 5.2, Font Awesome 6.1, and Roboto are **vendored** into `dist/vendor/` at build time
-  (copied from pinned `node_modules`) and referenced locally — no CDN at runtime (#24).
-- Sections rendered: header (photo + name + facts + PDF/QR), then `<main>` with About me, Skills
-  (bar chart), Professional Experience, Additional Experience, Robotics Competitions — each a
-  `<section id>` (nav anchor). On screen, About and the three experience sections present their content
-  as Bootstrap **cards**, while Skills keeps its bare bar-chart grid (un-carded, so its PDF output is
-  byte-identical). Lists use Handlebars
-  `{{#each}}` over the arrays above; a screen-only sticky **section nav** (a `<details>` menu below
-  Bootstrap `md`, an inline list at `md+`) links to the section ids, with its link list defined once as
-  a Handlebars inline partial.
+  Bootstrap, Font Awesome, and Roboto are **vendored** into `dist/vendor/` at build time; feature 003
+  added the vendored editorial webfonts **Fraunces** (display serif) and **Spline Sans** (body),
+  applied **screen-only** (`media="screen"`) so the PDF keeps Roboto — no CDN at runtime (#24).
+- **Sections.** Header (photo + name + facts + PDF/QR), then `<main>` with About me, Skills,
+  Professional Experience, Additional Experience, Robotics Competitions — each a `<section id>` (nav
+  anchor). A screen-only sticky **section nav** links to the section ids (a `<details>` menu below
+  Bootstrap `md`, an inline list at `md+`), its link list defined once as a Handlebars inline partial.
+- **The screen "deck" (feature 003).** On screen the page is a **full-viewport scroll-snap deck**: the
+  hero and each section fill the viewport and snap into place via native CSS `scroll-snap-type: y
+  mandatory` on `<html>` (no scroll-jacking JS). Skills **and** the three content-dense sections render
+  as horizontal **card rails** (`.cv-rail` of `.cv-summary` cards); activating a card opens the full
+  entry in a full-screen **detail overlay** — a CSS `:target` overlay (`#id` deep-linked, open/close
+  works with no JS). A fixed left-gutter **"Through-Line"** progress signature fills as you snap through
+  the deck, and a pure-CSS **swipe affordance** (right-edge fade + `›` chevron on `.cv-rail-wrap`) hints
+  the rails scroll. Skills are grouped into labelled category cards (Hard/Soft skills, Languages); the
+  overlay lists every skill in the category. See the
+  [interaction contract](../specs/003-interactive-card-rails/contracts/interaction-contract.md).
 - **`<base target="_blank">` gotcha.** The page sets `<base target="_blank">` so external links open
   in a new tab — but that default also applies to in-page anchors (`href="#…"`), which would then open
-  a new tab and reload the whole page. Every in-page anchor (the section-nav links, and any future
-  card/close/back anchors) must therefore set `target="_self"` to opt back out. See
+  a new tab and reload the whole page. Every in-page anchor (the section-nav links, the rail cards, and
+  the overlay close/backdrop links) must therefore set `target="_self"` to opt back out. See
   [interaction-gotchas.md](interaction-gotchas.md#in-page-anchors).
-- `src/assets/styles.css` holds project-specific styling on top of Bootstrap: the `screen` / `print`
-  visibility rules, the skill-bar styling, the card/section/nav layout, and the scroll-reveal. The
-  screen/print split is media-driven — `@media print` flattens the cards, hides the nav, and disables
-  motion so the PDF stays linear (Skills keeps its original grid markup, un-carded, so its print output
-  is byte-identical). See the [rendering contract](../specs/002-digital-cv-redesign/contracts/rendering-contract.md).
-- `src/assets/reveal.js` is a small progressive-enhancement script (loaded from `<head>`): it sets a
-  `.js` root class, then a one-shot `IntersectionObserver` reveals `.reveal` sections as they scroll
-  in. It **fails visible** — with no JS, no `IntersectionObserver`, or any error, all content stays
-  shown — and the reveal is disabled for reduced-motion users and in print.
+- **Styling & screen/print split.** `src/assets/styles.css` holds the project styling on top of
+  Bootstrap: the editorial palette + Fraunces/Spline type, the `screen` / `print` visibility rules, the
+  deck / rail / overlay / Through-Line layout, and the scroll-reveal. The split is media-driven —
+  `@media print` drops the deck's `100vh`/snap, flattens rails and overlays back to the original stacked
+  entries, renders Skills as labelled linear lists, and hides the nav / Through-Line / swipe affordance,
+  so the PDF stays byte-stable. `pdf.js` additionally emulates print media before navigating (see
+  *Build pipeline*).
+- **Progressive-enhancement scripts** (loaded from `<head>`, all fail-safe — with no JS, all content
+  stays reachable):
+  - `reveal.js` — sets a `.js` root class, then one-shot `IntersectionObserver`-reveals `.reveal`
+    sections; disabled under reduced-motion / no-JS / print.
+  - `deck.js` — one-section-per-keypress keyboard navigation over the snap deck, and drives the
+    Through-Line's active/progress state; never intercepts wheel/touch (native snap owns those).
+  - `overlay.js` — adds dialog semantics to the `:target` detail overlays (focus move-in, Tab-trap,
+    Escape-to-close, focus-return); the `:target` open/close works without it.
 - Note: this template/repo originates from the [`sneas/cv-template`](https://github.com/sneas/cv-template)
   project.
 
@@ -141,8 +156,9 @@ Font Awesome `<i>` tags and `<a>` links.
 
 The one automated test suite is a **visual-regression + PDF-render gate** (Playwright), not a
 unit/integration suite — it protects how the site renders across breakpoints and that the PDF still
-builds. It lives in `tests/` (`visual.spec.js`, `pdf.spec.js`, `snapshot.css`, committed baselines in
-`__screenshots__/`) with `playwright.config.js` at the root, runs via `make visual` / `make
+builds. It lives in `tests/` (`visual.spec.js` — fullPage breakpoint snapshots; `pdf.spec.js` — a
+valid-PDF check; `pdf-visual.spec.js` — a per-page pixel diff of the PDF; `snapshot.css`; committed
+baselines in `__screenshots__/`) with `playwright.config.js` at the root, runs via `make visual` / `make
 visual-update`, and is a required PR check. See [ci-cd.md](ci-cd.md#visual--pdf-gate) for how it runs
 and how baselines are updated.
 


### PR DESCRIPTION
Completes the last two milestone-003 tasks — the docs that shipped after the implementation. Closes #210, Closes #211.

## `docs/architecture.md` (#210)
Brought in sync with the shipped deck (and the #226 Skills rework):
- Rewrote **Template & styling** for the full-viewport **scroll-snap deck**, the **card rails + `:target` detail overlays**, the **Through-Line** signature, and the pure-CSS **swipe affordance**; documented `deck.js` / `overlay.js` / `reveal.js`.
- Added the screen-only vendored **Fraunces + Spline Sans**; fixed the `skills` data-model row (now `[{ category, kind, items }]`, no proficiency %); noted `pdf-visual.spec.js` in the layout + Tests.

## `docs/adr/0004-native-scroll-snap-editorial-deck.md` (#211, NEW)
The decision to build the CV as a native-scroll-snap deck (rails + `:target` overlays, screen-only, one signature). Notably records that **decision 5 reverses ADR 0003's "`pdf.js` unchanged (no `emulateMedia`)"** — `pdf.js` now emulates print media before navigating — and ties the tall-fullPage-gate trade-off to the open follow-ups (#225/#221/#223). Indexed in `docs/adr/README.md`; added an "Update (003)" back-reference note to ADR 0003 scoping what changed (decision 2) vs what stands (1 and 3).

## Verification
Two review passes confirmed every architecture.md claim is **true against the shipped code** and ADR 0004 is accurate/consistent. markdownlint clean; all cross-doc links resolve. Docs-only — no site/PDF impact.

Merging this closes **milestone 003** (last 2 of 30 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)